### PR TITLE
fix: prevent config clobber on corrupt JSON + atomic write

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ async function waitForProxyHealth(port: number, timeoutMs = 3000): Promise<boole
   return false;
 }
 import { OPENCLAW_MODELS } from "./models.js";
-import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync, copyFileSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { VERSION } from "./version.js";
@@ -111,6 +111,10 @@ function injectModelsConfig(logger: { info: (msg: string) => void }): void {
   }
 
   // Load existing config or create new one
+  // IMPORTANT: On parse failure, we backup and skip writing to avoid clobbering
+  // other plugins' config (e.g. Telegram channels). This prevents a race condition
+  // where a partial/corrupt config file causes us to overwrite everything with
+  // only our models+agents sections.
   if (existsSync(configPath)) {
     try {
       const content = readFileSync(configPath, "utf-8").trim();
@@ -121,11 +125,20 @@ function injectModelsConfig(logger: { info: (msg: string) => void }): void {
         needsWrite = true;
       }
     } catch (err) {
+      // Config file exists but is corrupt/invalid JSON — likely a partial write
+      // from another plugin or a race condition during gateway restart.
+      // Backup the corrupt file and SKIP writing to avoid losing other config.
+      const backupPath = `${configPath}.backup.${Date.now()}`;
+      try {
+        copyFileSync(configPath, backupPath);
+        logger.info(`Config parse failed, backed up to ${backupPath}`);
+      } catch {
+        logger.info("Config parse failed, could not create backup");
+      }
       logger.info(
-        `Failed to parse config (will recreate): ${err instanceof Error ? err.message : String(err)}`,
+        `Skipping config injection (corrupt file): ${err instanceof Error ? err.message : String(err)}`,
       );
-      config = {};
-      needsWrite = true;
+      return; // Don't write — we'd lose other plugins' config
     }
   } else {
     logger.info("OpenClaw config not found, creating");
@@ -278,9 +291,13 @@ function injectModelsConfig(logger: { info: (msg: string) => void }): void {
   }
 
   // Write config file if any changes were made
+  // Use atomic write (temp file + rename) to prevent partial writes that could
+  // corrupt the config and cause other plugins to lose their settings on next load.
   if (needsWrite) {
     try {
-      writeFileSync(configPath, JSON.stringify(config, null, 2));
+      const tmpPath = `${configPath}.tmp.${process.pid}`;
+      writeFileSync(tmpPath, JSON.stringify(config, null, 2));
+      renameSync(tmpPath, configPath);
       logger.info("Smart routing enabled (blockrun/auto)");
     } catch (err) {
       logger.info(`Failed to write config: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## Summary

- **On JSON parse failure**: backup the corrupt file and `return` early, instead of resetting `config = {}` and overwriting with only `models`+`agents` sections — which clobbers other plugins' config (e.g. Telegram channels)
- **Atomic write**: use `writeFileSync` to a temp file + `renameSync` to prevent partial writes that could corrupt `openclaw.json` for other plugins

## Problem

When installing ClawRouter via Telegram channel, the gateway restart can cause a race condition:

1. Gateway restarts → ClawRouter plugin loads → calls `injectModelsConfig()`
2. If `openclaw.json` is partially written or corrupt (from concurrent writes during restart), `JSON.parse()` fails
3. **Before this fix**: `config = {}` → only `models` + `agents` written back → Telegram channel config lost → `enabled: false` on next gateway load
4. **After this fix**: corrupt file is backed up, config injection is skipped, no data loss

## Test plan

- [x] Corrupt `~/.openclaw/openclaw.json` intentionally (e.g. `echo '{bad' > ...`), restart gateway, verify backup file created and existing config not overwritten
- [x] Normal install flow: verify `models` and `agents` sections still injected correctly
- [x] Verify Telegram channel config survives ClawRouter install/gateway restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)