### PR TITLE
fix: rename sonnet/opus/haiku aliases to avoid shadowing core models

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -251,9 +251,9 @@ function injectModelsConfig(logger: { info: (msg: string) => void }): void {
     { id: "eco", alias: "eco" },
     { id: "premium", alias: "premium" },
     { id: "free", alias: "free" },
-    { id: "sonnet", alias: "sonnet" },
-    { id: "opus", alias: "opus" },
-    { id: "haiku", alias: "haiku" },
+    { id: "sonnet", alias: "br-sonnet" },
+    { id: "opus", alias: "br-opus" },
+    { id: "haiku", alias: "br-haiku" },
     { id: "gpt5", alias: "gpt5" },
     { id: "mini", alias: "mini" },
     { id: "grok-fast", alias: "grok-fast" },
@@ -284,11 +284,15 @@ function injectModelsConfig(logger: { info: (msg: string) => void }): void {
     }
   }
 
-  // Add current aliases
+  // Add current aliases (and update stale aliases)
   for (const m of KEY_MODEL_ALIASES) {
     const fullId = `blockrun/${m.id}`;
-    if (!allowlist[fullId]) {
+    const existing = allowlist[fullId] as Record<string, unknown> | undefined;
+    if (!existing) {
       allowlist[fullId] = { alias: m.alias };
+      needsWrite = true;
+    } else if (existing.alias !== m.alias) {
+      existing.alias = m.alias;
       needsWrite = true;
     }
   }


### PR DESCRIPTION
## Summary
- Rename `blockrun/sonnet`, `blockrun/opus`, `blockrun/haiku` aliases from `sonnet`/`opus`/`haiku` to `br-sonnet`/`br-opus`/`br-haiku`
- The old aliases shadow OpenClaw's core Anthropic model aliases, causing `primary: "sonnet"` to route through blockrun instead of the local Claude CLI backend
- Update alias injection logic to fix stale aliases in existing configs

## Details

When a user sets `agents.defaults.model.primary: "sonnet"`, they expect it to resolve to `anthropic/claude-sonnet-4-5` (local Claude CLI). But ClawRouter registers `blockrun/sonnet` with `alias: "sonnet"`, which takes priority and routes through the blockrun proxy instead.

After this change:
- `sonnet` / `opus` / `haiku` resolve to core Anthropic models (Claude CLI)
- `br-sonnet` / `br-opus` / `br-haiku` resolve to blockrun-proxied variants
- `blockrun/sonnet` etc. still work as direct model references

## Test plan
- [ ] Set `primary: "sonnet"` and verify gateway logs `agent model: anthropic/claude-sonnet-4-5`
- [ ] Verify `/model br-sonnet` routes through blockrun proxy
- [ ] Verify existing configs with old aliases get updated on restart