### PR TITLE
feat: add custom paymentFetch option to proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/clawrouter",
-  "version": "0.10.4",
+  "version": "0.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/clawrouter",
-      "version": "0.10.4",
+      "version": "0.10.6",
       "license": "MIT",
       "dependencies": {
         "viem": "^2.39.3"


### PR DESCRIPTION
## Summary

- Adds optional `paymentFetch` parameter to `startProxy()` for custom payment handlers
- Enables integration of alternative payment systems (spend limits, budget enforcement, etc.)
- Falls back to built-in x402 payment handler when not provided

## Test plan

- [x] Verify existing behavior unchanged when `paymentFetch` is not provided
- [x] Test custom `paymentFetch` function is called when provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)