### PR TITLE
docs: fix badge alt text to match displayed content

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ One wallet, 41+ models, zero API keys.
 
 <img src="https://img.shields.io/badge/🚀_92%25_Cost_Savings-success?style=for-the-badge" alt="92% savings">&nbsp;
 <img src="https://img.shields.io/badge/🔑_Zero_API_Keys-blue?style=for-the-badge" alt="No API keys">&nbsp;
-<img src="https://img.shields.io/badge/🤖_41+_Models-purple?style=for-the-badge" alt="38+ models">&nbsp;
+<img src="https://img.shields.io/badge/🤖_41+_Models-purple?style=for-the-badge" alt="41+ models">&nbsp;
 <img src="https://img.shields.io/badge/💰_Non--Custodial-orange?style=for-the-badge" alt="Non-custodial">&nbsp;
 <img src="https://img.shields.io/badge/⚡_<1ms_Routing-yellow?style=for-the-badge" alt="Fast routing">
 


### PR DESCRIPTION
## Summary
- Fixed mismatch between badge display text and alt text on line 13 of README.md
- Badge shows "41+ Models" but alt text said "38+ models" — updated alt text to "41+ models"

## Test plan
- [ ] Verify badge alt text matches displayed badge content in rendered README