### PR TITLE
Fix #36: Correct USDC decimal precision in balance display

### DIFF
--- a/src/balance.ts
+++ b/src/balance.ts
@@ -149,12 +149,13 @@ export class BalanceMonitor {
   }
 
   /**
-   * Format USDC amount (in micros) as "$X.XX".
+   * Format USDC amount (in micros) as "$X.XXXX".
+   * Uses 4 decimal places for consistency with stats display.
    */
   formatUSDC(amountMicros: bigint): string {
     // USDC has 6 decimals
     const dollars = Number(amountMicros) / 1_000_000;
-    return `$${dollars.toFixed(2)}`;
+    return `$${dollars.toFixed(4)}`;
   }
 
   /**


### PR DESCRIPTION
## Problem
Issue #36 reported that the dashboard shows incorrect USDC amounts - for example, showing $0.01 when the actual on-chain cost is 0.004 USDC.

## Root Cause
The `formatUSDC` function in `balance.ts` used `toFixed(2)` (2 decimal places), while the stats dashboard uses `toFixed(4)` (4 decimal places). This inconsistency caused small amounts to be rounded incorrectly.

## Solution
- Changed `formatUSDC` to use `toFixed(4)` for consistent precision
- Updated JSDoc comment to reflect the change
- Now matches the precision used in `stats.ts` dashboard display

## Changes
- `src/balance.ts`: Changed `$${dollars.toFixed(2)}` → `$${dollars.toFixed(4)}`

## Testing
- All existing tests pass (212 passed)
- Build succeeds without errors
- Verified consistent display with `/stats` command output

Fixes #36