### PR TITLE
Add chat badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ One wallet, 41+ models, zero API keys.
 [![CI](https://img.shields.io/github/actions/workflow/status/BlockRunAI/ClawRouter/ci.yml?style=flat-square&label=CI)](https://github.com/BlockRunAI/ClawRouter/actions)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178c6?style=flat-square&logo=typescript&logoColor=white)](https://typescriptlang.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green?style=flat-square)](LICENSE)
+[![Chat with Repo](https://badge.forgithub.com/BlockRunAI/ClawRouter?badge=chat)](https://uithub.com/BlockRunAI/ClawRouter)
 
 [![USDC Hackathon Winner](https://img.shields.io/badge/🏆_USDC_Hackathon-Agentic_Commerce_Winner-gold?style=flat-square)](https://x.com/USDC/status/2021625822294216977)
 [![x402 Protocol](https://img.shields.io/badge/x402-Micropayments-purple?style=flat-square)](https://x402.org)


### PR DESCRIPTION
This adds the following badge to your badges, which allows people to more easily chat with the repo (with LLMs) without having to clone it first.

[![Chat with Repo](https://badge.forgithub.com/BlockRunAI/ClawRouter?badge=chat)](https://uithub.com/BlockRunAI/ClawRouter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Chat with Repo" badge to the README for quick access to chat support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->