### PR TITLE
chore: sync ClawRouter fork with upstream and keep Lionroot routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md — ClawRouter
+
+## Project
+15-dimension weighted scoring classifies prompts in <1ms. Routes to cheapest model that can handle each request. MIT licensed, zero external calls.
+
+## Structure
+```
+src/              ← Routing engine, scoring dimensions, model configs
+docs/             ← Architecture, configuration, features, troubleshooting
+skills/           ← OpenClaw skill integration
+test/             ← Test suites
+scripts/          ← Install and utility scripts
+```
+
+## Build & Test
+```bash
+npm install
+npm run build     # tsup
+npm test          # vitest
+npm run lint      # eslint
+```
+
+## Docs
+Check `docs/` before making changes. Key files:
+- `docs/architecture.md` — routing engine internals
+- `docs/configuration.md` — model configs, tier definitions
+- `docs/features.md` — scoring dimensions, agentic mode
+- `docs/troubleshooting.md` — common issues
+
+## Related Projects
+- **CLI Proxy**: ~/clawd/openclaw-cli-proxy (receives classified model IDs)
+- **Gateway**: ~/clawdbot (uses ClawRouter via proxy)
+- **Lionroot Hub**: ~/programming_projects/lionroot-openclaw (STRATEGY.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1217,15 +1217,6 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@discordjs/voice/node_modules/opusscript": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
-      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",

--- a/src/proxy.degraded-response.test.ts
+++ b/src/proxy.degraded-response.test.ts
@@ -52,6 +52,89 @@ Yes.`,
     expect(result).toBeDefined();
   });
 
+  it("flags overloaded output in SSE stream-like JSONL payload", () => {
+    const payload = [
+      'data: {"choices":[{"delta":{"content":"The AI service is temporarily overloaded. Please try again in a moment."}]}',
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n");
+
+    const result = detectDegradedSuccessResponse(payload);
+    expect(result).toBeDefined();
+  });
+
+  it("flags SSE payload with you've-hit-your-limit phrasing", () => {
+    const payload = [
+      'data: {"choices":[{"delta":{"content":"You\'ve hit your limit · resets Feb 26 at 10am (America/New_York)"}]}',
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n");
+
+    const result = detectDegradedSuccessResponse(payload);
+    expect(result).toBeDefined();
+  });
+
+  it("flags OAuth token refresh failures in plain text", () => {
+    const payload =
+      "OAuth token refresh failed for anthropic: Failed to refresh OAuth token for anthropic. Please try again or re-authenticate.";
+
+    const result = detectDegradedSuccessResponse(payload);
+    expect(result).toBeDefined();
+  });
+
+  it("flags payment verification failed in plain text", () => {
+    const payload = "Payment verification failed: Invalid signature";
+
+    const result = detectDegradedSuccessResponse(payload);
+    expect(result).toBeDefined();
+  });
+
+  it("flags contraction-style rate-limit phrasing", () => {
+    const payload = JSON.stringify({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "You've hit your limit · resets Feb 26 at 10am (America/New_York)",
+          },
+        },
+      ],
+    });
+
+    const result = detectDegradedSuccessResponse(payload);
+    expect(result).toBeDefined();
+  });
+
+  it("flags payment verification failed in successful chat response JSON", () => {
+    const payload = JSON.stringify({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "Payment verification failed",
+          },
+        },
+      ],
+    });
+
+    const result = detectDegradedSuccessResponse(payload);
+    expect(result).toBeDefined();
+  });
+
+  it("flags payment verification failed in SSE stream chunks", () => {
+    const payload = [
+      'data: {"choices":[{"delta":{"content":"Payment verification failed"}]}',
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n");
+
+    const result = detectDegradedSuccessResponse(payload);
+    expect(result).toBeDefined();
+  });
+
   it("does not flag normal assistant responses", () => {
     const payload = JSON.stringify({
       choices: [

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -338,6 +338,9 @@ const PROVIDER_ERROR_PATTERNS = [
   /credits/i,
   /quota.*exceeded/i,
   /rate.*limit/i,
+  /you\s*have\s*hit\s*your\s*limit/i,
+  /you['’]ve\s*hit\s*your\s*limit/i,
+  /rate\s*limited/i,
   /model.*unavailable/i,
   /model.*not.*available/i,
   /service.*unavailable/i,
@@ -346,12 +349,28 @@ const PROVIDER_ERROR_PATTERNS = [
   /temporarily.*unavailable/i,
   /api.*key.*invalid/i,
   /authentication.*failed/i,
+  /oauth/i,
+  /auth.*failed/i,
   /request too large/i,
   /request.*size.*exceeds/i,
   /payload too large/i,
   /payment.*verification.*failed/i,
   /model.*not.*allowed/i,
-  /unknown.*model/i,
+  /too many requests/i,
+];
+
+/**
+ * Patterns that indicate client request bugs and should stop fallback.
+ */
+const CLIENT_BUG_PATTERNS = [
+  /messages\s+must\s+be/i,
+  /invalid\s+request/i,
+  /unknown\s+parameter/i,
+  /failed\s+to\s+parse/i,
+  /invalid\s+json/i,
+  /model\s+not\s+found/i,
+  /unknown\s+model/i,
+  /invalid\s+model/i,
 ];
 
 /**
@@ -362,6 +381,9 @@ const DEGRADED_RESPONSE_PATTERNS = [
   /the ai service is temporarily overloaded/i,
   /service is temporarily overloaded/i,
   /please try again in a moment/i,
+  /you\s*have\s*hit\s*your\s*limit/i,
+  /you['’]ve\s*hit\s*your\s*limit/i,
+  /you\s*have\s*been\s*rate\s*limited/i,
 ];
 
 /**
@@ -373,6 +395,248 @@ const DEGRADED_LOOP_PATTERNS = [
   /the final answer is the boxed\./i,
 ];
 
+const RATE_LIMIT_PATTERNS = [
+  /rate\s*limit/i,
+  /too\s*many\s*requests/i,
+  /you\s*have\s*hit\s*your\s*limit/i,
+  /you['’]ve\s*hit\s*your\s*limit/i,
+  /hit\s*your\s*limit/i,
+];
+const BILLING_PATTERNS = [/billing/i, /credits/i, /insufficient.*balance/i, /quota/i, /payment/i];
+const AUTH_PATTERNS = [/invalid\s+api\s+key/i, /oauth/i, /auth/i, /unauthorized/i, /forbidden/i, /expired/i];
+const OUTAGE_PATTERNS = [/service\s+unavailable/i, /temporarily\s+unavailable/i, /overloaded/i, /capacity/i];
+
+type UpstreamError = {
+  message: string;
+  type?: string;
+};
+
+type ProviderFailureClassification = {
+  isProviderError: boolean;
+  isClientBug: boolean;
+  isRateLimited: boolean;
+  reason: string;
+  error?: UpstreamError;
+};
+
+function anyPatternMatch(message: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(message));
+}
+
+function looksLikeSse(body: string): boolean {
+  return /(^|\n)\s*data:\s*/m.test(body);
+}
+
+function parseSsePayloads(body: string): unknown[] {
+  const events: unknown[] = [];
+  const normalized = body.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+
+  for (const line of lines) {
+    const match = line.match(/^\s*data:\s*(.*)$/);
+    if (!match) continue;
+
+    const data = match[1]?.trim();
+    if (!data || data === "[DONE]") continue;
+
+    try {
+      events.push(JSON.parse(data));
+    } catch {
+      // Ignore non-JSON SSE payloads
+    }
+  }
+
+  return events;
+}
+
+function extractUpstreamErrorFromPayload(payload: unknown): UpstreamError | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+
+  const obj = payload as Record<string, unknown>;
+
+  // Standard OpenAI-style { error: { message, type } }
+  const errorValue = obj.error;
+  if (typeof errorValue === "string") {
+    return { message: errorValue };
+  }
+  if (errorValue && typeof errorValue === "object") {
+    const errorObj = errorValue as Record<string, unknown>;
+    if (typeof errorObj.message === "string") {
+      return {
+        message: errorObj.message,
+        type: typeof errorObj.type === "string" ? errorObj.type : undefined,
+      };
+    }
+  }
+
+  // CLI-style { is_error: true, result: "..." }
+  if (
+    obj.is_error === true &&
+    typeof obj.result === "string" &&
+    obj.result.trim().length > 0
+  ) {
+    return {
+      message: obj.result,
+      type: "proxy_error",
+    };
+  }
+
+  // Alternative error envelope: { type: "error", message: "..." }
+  if (obj.type === "error" && typeof obj.message === "string") {
+    return { message: obj.message, type: "proxy_error" };
+  }
+
+  return undefined;
+}
+
+function extractUpstreamError(body: string): UpstreamError | undefined {
+  if (!body) return undefined;
+
+  if (looksLikeSse(body)) {
+    for (const event of parseSsePayloads(body)) {
+      const error = extractUpstreamErrorFromPayload(event);
+      if (error) return error;
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    return extractUpstreamErrorFromPayload(parsed);
+  } catch {
+    return undefined;
+  }
+}
+
+function classifyProviderFailure(params: {
+  status: number;
+  body: string;
+  contentType?: string | null;
+}): ProviderFailureClassification {
+  const { status, body } = params;
+
+  const normalizedBody = body || "";
+  const upstreamError = extractUpstreamError(normalizedBody);
+  if (upstreamError?.message) {
+    const message = upstreamError.message;
+    const isClientBug = anyPatternMatch(message, CLIENT_BUG_PATTERNS);
+
+    if (status === 200) {
+      return {
+        isProviderError: !isClientBug,
+        isClientBug,
+        isRateLimited: anyPatternMatch(message, RATE_LIMIT_PATTERNS),
+        reason: isClientBug ? "embedded_client_error" : "embedded_provider_error",
+        error: upstreamError,
+      };
+    }
+
+    if (status === 400) {
+      const isProvider =
+        !isClientBug &&
+        (anyPatternMatch(message, PROVIDER_ERROR_PATTERNS) ||
+          anyPatternMatch(message, RATE_LIMIT_PATTERNS) ||
+          anyPatternMatch(message, BILLING_PATTERNS) ||
+          anyPatternMatch(message, AUTH_PATTERNS) ||
+          anyPatternMatch(message, OUTAGE_PATTERNS));
+
+      return {
+        isProviderError: isProvider,
+        isClientBug,
+        isRateLimited: anyPatternMatch(message, RATE_LIMIT_PATTERNS),
+        reason: isProvider ? "400_embedded_provider_error" : "400_embedded_client_error",
+        error: upstreamError,
+      };
+    }
+  }
+
+  // 200 responses can carry provider failures in success envelopes.
+  if (status === 200) {
+    const degraded = detectDegradedSuccessResponse(normalizedBody);
+    if (degraded) {
+      return {
+        isProviderError: true,
+        isClientBug: false,
+        isRateLimited: anyPatternMatch(normalizedBody, RATE_LIMIT_PATTERNS),
+        reason: degraded,
+      };
+    }
+
+    return {
+      isProviderError: false,
+      isClientBug: false,
+      isRateLimited: false,
+      reason: "200_success",
+    };
+  }
+
+  // Non-200 provider status handling
+  if (!FALLBACK_STATUS_CODES.includes(status)) {
+    return {
+      isProviderError: false,
+      isClientBug: false,
+      isRateLimited: false,
+      reason: `status_${status}_non_fallback`,
+    };
+  }
+
+  if (status === 429) {
+    return {
+      isProviderError: true,
+      isClientBug: false,
+      isRateLimited: true,
+      reason: "status_429",
+      error: upstreamError,
+    };
+  }
+
+  if (status === 401 || status === 403 || status === 402) {
+    return {
+      isProviderError: true,
+      isClientBug: false,
+      isRateLimited: false,
+      reason: `status_${status}`,
+      error: upstreamError,
+    };
+  }
+
+  if (status >= 500) {
+    return {
+      isProviderError: true,
+      isClientBug: false,
+      isRateLimited: false,
+      reason: `status_${status}`,
+      error: upstreamError,
+    };
+  }
+
+  // 400 is ambiguous; only fallback when strongly provider-like.
+  if (status === 400) {
+    const providerLike =
+      anyPatternMatch(normalizedBody, PROVIDER_ERROR_PATTERNS) ||
+      anyPatternMatch(normalizedBody, RATE_LIMIT_PATTERNS) ||
+      anyPatternMatch(normalizedBody, BILLING_PATTERNS) ||
+      anyPatternMatch(normalizedBody, AUTH_PATTERNS) ||
+      anyPatternMatch(normalizedBody, OUTAGE_PATTERNS);
+    return {
+      isProviderError: providerLike,
+      isClientBug: !providerLike,
+      isRateLimited: anyPatternMatch(normalizedBody, RATE_LIMIT_PATTERNS),
+      reason: providerLike ? "400_provider_like" : "400_client_like",
+      error: upstreamError,
+    };
+  }
+
+  // Other mapped fallback statuses (413 etc.)
+  const providerLike = anyPatternMatch(normalizedBody, PROVIDER_ERROR_PATTERNS);
+  return {
+    isProviderError: providerLike,
+    isClientBug: false,
+    isRateLimited: false,
+    reason: `status_${status}`,
+    error: upstreamError,
+  };
+}
+
 function extractAssistantContent(payload: unknown): string | undefined {
   if (!payload || typeof payload !== "object") return undefined;
   const record = payload as Record<string, unknown>;
@@ -382,10 +646,27 @@ function extractAssistantContent(payload: unknown): string | undefined {
   const firstChoice = choices[0];
   if (!firstChoice || typeof firstChoice !== "object") return undefined;
   const choice = firstChoice as Record<string, unknown>;
+
   const message = choice.message;
-  if (!message || typeof message !== "object") return undefined;
-  const content = (message as Record<string, unknown>).content;
-  return typeof content === "string" ? content : undefined;
+  if (message && typeof message === "object") {
+    const content = (message as Record<string, unknown>).content;
+    if (typeof content === "string") return content;
+  }
+
+  const delta = choice.delta;
+  if (delta && typeof delta === "object") {
+    const content = (delta as Record<string, unknown>).content;
+    if (typeof content === "string") return content;
+  }
+
+  return undefined;
+}
+
+function isDegradedResponseText(text: string): boolean {
+  return (
+    DEGRADED_RESPONSE_PATTERNS.some((pattern) => pattern.test(text)) ||
+    PROVIDER_ERROR_PATTERNS.some((pattern) => pattern.test(text))
+  );
 }
 
 function hasKnownLoopSignature(text: string): boolean {
@@ -420,9 +701,45 @@ export function detectDegradedSuccessResponse(body: string): string | undefined 
   const trimmed = body.trim();
   if (!trimmed) return undefined;
 
+  if (looksLikeSse(trimmed)) {
+    const parsedEvents = parseSsePayloads(trimmed);
+    const assistantChunks: string[] = [];
+
+    for (const event of parsedEvents) {
+      const eventError = extractUpstreamErrorFromPayload(event);
+      if (eventError?.message &&
+        (PROVIDER_ERROR_PATTERNS.some((pattern) => pattern.test(eventError.message)) ||
+          DEGRADED_RESPONSE_PATTERNS.some((pattern) => pattern.test(eventError.message)))
+      ) {
+        return `degraded response: ${eventError.message.slice(0, 120)}`;
+      }
+
+      const assistantContent = extractAssistantContent(event);
+      if (assistantContent) {
+        assistantChunks.push(assistantContent);
+      }
+    }
+
+    const assistantText = assistantChunks.join("");
+    if (assistantText) {
+      if (isDegradedResponseText(assistantText)) {
+        return "degraded response: degraded assistant content";
+      }
+      if (hasKnownLoopSignature(assistantText)) {
+        return "degraded response: repetitive assistant loop";
+      }
+    }
+
+    // Continue with fallback checks below for non-stream patterns.
+  }
+
   // Plain-text placeholder response.
   if (DEGRADED_RESPONSE_PATTERNS.some((pattern) => pattern.test(trimmed))) {
     return "degraded response: overloaded placeholder";
+  }
+
+  if (PROVIDER_ERROR_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+    return "degraded response: provider error pattern";
   }
 
   // Plain-text looping garbage response.
@@ -434,29 +751,19 @@ export function detectDegradedSuccessResponse(body: string): string | undefined 
     const parsed = JSON.parse(trimmed) as Record<string, unknown>;
 
     // Some providers return JSON error payloads with HTTP 200.
-    const errorField = parsed.error;
-    let errorText = "";
-    if (typeof errorField === "string") {
-      errorText = errorField;
-    } else if (errorField && typeof errorField === "object") {
-      const errObj = errorField as Record<string, unknown>;
-      errorText = [
-        typeof errObj.message === "string" ? errObj.message : "",
-        typeof errObj.type === "string" ? errObj.type : "",
-        typeof errObj.code === "string" ? errObj.code : "",
-      ]
-        .filter(Boolean)
-        .join(" ");
-    }
-    if (errorText && PROVIDER_ERROR_PATTERNS.some((pattern) => pattern.test(errorText))) {
-      return `degraded response: ${errorText.slice(0, 120)}`;
+    const parsedError = extractUpstreamErrorFromPayload(parsed);
+    if (parsedError?.message) {
+      const { message } = parsedError;
+      if (DEGRADED_RESPONSE_PATTERNS.some((pattern) => pattern.test(message))) {
+        return `degraded response: ${message.slice(0, 120)}`;
+      }
     }
 
     // Successful wrapper with bad assistant content.
     const assistantContent = extractAssistantContent(parsed);
     if (!assistantContent) return undefined;
-    if (DEGRADED_RESPONSE_PATTERNS.some((pattern) => pattern.test(assistantContent))) {
-      return "degraded response: overloaded assistant content";
+    if (isDegradedResponseText(assistantContent)) {
+      return "degraded response: degraded assistant content";
     }
     if (hasKnownLoopSignature(assistantContent)) {
       return "degraded response: repetitive assistant loop";
@@ -483,24 +790,6 @@ const FALLBACK_STATUS_CODES = [
   503, // Service unavailable
   504, // Gateway timeout
 ];
-
-/**
- * Check if an error response indicates a provider issue that should trigger fallback.
- */
-function isProviderError(status: number, body: string): boolean {
-  // Check status code first
-  if (!FALLBACK_STATUS_CODES.includes(status)) {
-    return false;
-  }
-
-  // For 5xx errors, always fallback
-  if (status >= 500) {
-    return true;
-  }
-
-  // For 4xx errors, check the body for known provider error patterns
-  return PROVIDER_ERROR_PATTERNS.some((pattern) => pattern.test(body));
-}
 
 /**
  * Valid message roles for OpenAI-compatible APIs.
@@ -1651,6 +1940,7 @@ type ModelRequestResult = {
   errorBody?: string;
   errorStatus?: number;
   isProviderError?: boolean;
+  isRateLimited?: boolean;
 };
 
 /**
@@ -1720,31 +2010,45 @@ async function tryModelRequest(
     });
 
     // Check for provider errors
+    const contentType = response.headers.get("content-type") || "";
     if (response.status !== 200) {
-      // Clone response to read body without consuming it
       const errorBody = await response.text();
-      const isProviderErr = isProviderError(response.status, errorBody);
+      const classification = classifyProviderFailure({
+        status: response.status,
+        body: errorBody,
+        contentType,
+      });
 
       return {
         success: false,
         errorBody,
         errorStatus: response.status,
-        isProviderError: isProviderErr,
+        isProviderError: classification.isProviderError,
+        isRateLimited: classification.isRateLimited,
       };
     }
 
     // Detect provider degradation hidden inside HTTP 200 responses.
-    const contentType = response.headers.get("content-type") || "";
-    if (contentType.includes("json") || contentType.includes("text")) {
+    if (contentType.includes("json") || contentType.includes("text") || contentType.includes("x-ndjson")) {
       try {
         const responseBody = await response.clone().text();
-        const degradedReason = detectDegradedSuccessResponse(responseBody);
-        if (degradedReason) {
+        const classification = classifyProviderFailure({
+          status: response.status,
+          body: responseBody,
+          contentType,
+        });
+
+        if (classification.isProviderError) {
+          const syntheticErrorStatus = classification.isClientBug
+            ? 400
+            : 502;
+
           return {
             success: false,
-            errorBody: degradedReason,
-            errorStatus: 503,
-            isProviderError: true,
+            errorBody: classification.error?.message || "provider error in 200 response",
+            errorStatus: syntheticErrorStatus,
+            isProviderError: classification.isProviderError,
+            isRateLimited: classification.isRateLimited,
           };
         }
       } catch {
@@ -2803,8 +3107,8 @@ async function proxyRequest(
 
       // If it's a provider error and not the last attempt, try next model
       if (result.isProviderError && !isLastAttempt) {
-        // Track 429 rate limits to deprioritize this model for future requests
-        if (result.errorStatus === 429) {
+        // Track provider rate limits to deprioritize this model for future requests
+        if ((result.errorStatus === 429) || result.isRateLimited) {
           markRateLimited(tryModel);
         }
 

--- a/src/router/config.lionheart.ts
+++ b/src/router/config.lionheart.ts
@@ -1,0 +1,138 @@
+/**
+ * Lionheart Custom Routing Config
+ *
+ * Local-first routing: uses free local models for simple/medium tasks,
+ * Claude subscription for complex/reasoning, DeepSeek as cheap cloud fallback.
+ *
+ * Backends (via CLI proxy at 127.0.0.1:11435):
+ *   - EXO (localhost:52415)      → Llama 3.1 8B on Apple Silicon ($0)
+ *   - Ollama (daddyo-gaming)     → Qwen3 14B on RTX 3080 ($0, native tool calling)
+ *   - Claude CLI (subscription)  → Sonnet/Opus via `claude --print`
+ *   - DeepSeek API               → deepseek-chat / deepseek-reasoner (pay-per-token)
+ *
+ * Model ID convention (matches CLI proxy routing):
+ *   local/exo-llama-8b       → EXO Llama 3.1 8B
+ *   local/ollama-qwen3-14b   → Ollama Qwen3 14B (CUDA, tool calling)
+ *   local/exo-llama-3b       → EXO Llama 3.2 3B (fast)
+ *   claude-cli/sonnet         → Claude Sonnet 4.5 (subscription)
+ *   claude-cli/opus           → Claude Opus 4.6 (subscription)
+ *   deepseek/deepseek-chat    → DeepSeek V3 ($0.14/$0.28 per M tokens)
+ *   deepseek/deepseek-reasoner → DeepSeek R1 ($0.55/$2.19 per M tokens)
+ */
+
+import type { RoutingConfig } from "./types.js";
+import { DEFAULT_ROUTING_CONFIG } from "./config.js";
+
+export const LIONHEART_ROUTING_CONFIG: RoutingConfig = {
+  ...DEFAULT_ROUTING_CONFIG,
+
+  tiers: {
+    // SIMPLE: greetings, definitions, translations, yes/no questions
+    // → Free local model, fast response, no quota burn
+    SIMPLE: {
+      primary: "local/exo-llama-8b",
+      fallback: [
+        "local/ollama-qwen3-14b",
+        "deepseek/deepseek-chat",
+        "claude-cli/sonnet",
+      ],
+    },
+
+    // MEDIUM: code tasks, technical questions, multi-step instructions
+    // → Ollama Qwen3 14B handles this well with native tool calling
+    MEDIUM: {
+      primary: "local/ollama-qwen3-14b",
+      fallback: [
+        "deepseek/deepseek-chat",
+        "claude-cli/sonnet",
+        "local/exo-llama-8b",
+      ],
+    },
+
+    // COMPLEX: architecture design, complex analysis, long-context tasks
+    // → Claude Sonnet via subscription (no per-token cost)
+    COMPLEX: {
+      primary: "claude-cli/sonnet",
+      fallback: [
+        "deepseek/deepseek-chat",
+        "claude-cli/opus",
+        "local/ollama-qwen3-14b",
+      ],
+    },
+
+    // REASONING: proofs, formal derivation, chain-of-thought, math
+    // → Claude Opus for best reasoning, DeepSeek Reasoner as cheap fallback
+    REASONING: {
+      primary: "claude-cli/opus",
+      fallback: [
+        "deepseek/deepseek-reasoner",
+        "claude-cli/sonnet",
+      ],
+    },
+  },
+
+  // Agentic tiers: models with strong tool calling for multi-step tasks
+  // Key: Ollama Qwen3 14B has native OpenAI tool calling (0.971 F1)
+  agenticTiers: {
+    SIMPLE: {
+      primary: "local/ollama-qwen3-14b",  // Native tool calling, $0
+      fallback: [
+        "deepseek/deepseek-chat",
+        "claude-cli/sonnet",
+      ],
+    },
+    MEDIUM: {
+      primary: "local/ollama-qwen3-14b",  // Strong tool calling for coding
+      fallback: [
+        "claude-cli/sonnet",
+        "deepseek/deepseek-chat",
+      ],
+    },
+    COMPLEX: {
+      primary: "claude-cli/sonnet",
+      fallback: [
+        "claude-cli/opus",
+        "deepseek/deepseek-chat",
+        "local/ollama-qwen3-14b",
+      ],
+    },
+    REASONING: {
+      primary: "claude-cli/opus",
+      fallback: [
+        "deepseek/deepseek-reasoner",
+        "claude-cli/sonnet",
+      ],
+    },
+  },
+
+  overrides: {
+    ...DEFAULT_ROUTING_CONFIG.overrides,
+    // Lower threshold since local models have small context windows
+    maxTokensForceComplex: 8_000,
+    // Default ambiguous to MEDIUM (routes to Ollama, free)
+    ambiguousDefaultTier: "MEDIUM",
+  },
+};
+
+/**
+ * Model pricing for cost estimation and savings calculation.
+ * Local models are $0. Claude CLI is subscription (treat as $0 marginal cost).
+ * Only DeepSeek has real per-token costs.
+ */
+export const LIONHEART_MODEL_PRICING = new Map([
+  // Local models — $0
+  ["local/exo-llama-8b", { inputPrice: 0, outputPrice: 0 }],
+  ["local/exo-llama-3b", { inputPrice: 0, outputPrice: 0 }],
+  ["local/ollama-qwen3-14b", { inputPrice: 0, outputPrice: 0 }],
+
+  // Claude CLI — subscription, no marginal cost per token
+  ["claude-cli/sonnet", { inputPrice: 0, outputPrice: 0 }],
+  ["claude-cli/opus", { inputPrice: 0, outputPrice: 0 }],
+
+  // DeepSeek — pay-per-token (prices in $ per 1M tokens)
+  ["deepseek/deepseek-chat", { inputPrice: 0.14, outputPrice: 0.28 }],
+  ["deepseek/deepseek-reasoner", { inputPrice: 0.55, outputPrice: 2.19 }],
+
+  // Baseline for savings comparison (Opus API pricing)
+  ["anthropic/claude-opus-4", { inputPrice: 15.0, outputPrice: 75.0 }],
+]);

--- a/src/router/config.lionheart.ts
+++ b/src/router/config.lionheart.ts
@@ -1,28 +1,30 @@
 /**
- * Lionheart Custom Routing Config
+ * Lionheart Custom Routing Config — AlexFinn Three-Tier Strategy
  *
- * Local-first routing: uses free local models for simple/medium tasks,
- * Claude subscription for complex/reasoning, DeepSeek as cheap cloud fallback.
+ * Strategy (per @AlexFinn recommendation):
+ *   1. Opus as orchestrator — planning, reasoning, complex analysis
+ *   2. Codex GPT for coding — code generation, multi-step technical tasks
+ *   3. Qwen 3.5 small models for dirty work — heartbeat, organizing, summarizing (~70%)
  *
  * Backends (via CLI proxy at 127.0.0.1:11435):
- *   - EXO (localhost:52415)      → Llama 3.1 8B on Apple Silicon ($0)
- *   - Ollama (daddyo-gaming)     → Qwen3 14B on RTX 3080 ($0, native tool calling)
- *   - Claude CLI (subscription)  → Sonnet/Opus via `claude --print`
- *   - Codex CLI (subscription)   → GPT-5.3 Codex / o3 via `codex --full-auto`
- *   - DeepSeek API               → deepseek-chat / deepseek-reasoner (pay-per-token)
+ *   - Ollama (local, Apple Silicon) → Qwen3.5 4B/0.8B/9B ($0, native tool calling)
+ *   - Ollama (local)               → Qwen3 14B ($0, legacy workhorse)
+ *   - Claude CLI (subscription)    → Opus 4.6 orchestrator via `claude --print`
+ *   - Codex CLI (subscription)     → GPT-5.3 Codex / o3 via `codex --full-auto`
+ *   - DeepSeek API                 → deepseek-chat / deepseek-reasoner (pay-per-token)
  *
  * Fallback priority: local($0) → subscription($0 marginal) → cloud(per-token)
- * When hitting Claude weekly limits, Codex is tried before DeepSeek.
  *
  * Model ID convention (matches CLI proxy routing):
- *   local/exo-llama-8b       → EXO Llama 3.1 8B
- *   local/ollama-qwen3-14b   → Ollama Qwen3 14B (CUDA, tool calling)
- *   local/exo-llama-3b       → EXO Llama 3.2 3B (fast)
- *   claude-cli/sonnet         → Claude Sonnet 4.5 (subscription)
- *   claude-cli/opus           → Claude Opus 4.6 (subscription)
- *   codex/gpt-5.3             → GPT-5.3 Codex (subscription, code specialist)
- *   codex/o3                  → OpenAI o3 (subscription, reasoning specialist)
- *   deepseek/deepseek-chat    → DeepSeek V3 ($0.14/$0.28 per M tokens)
+ *   local/ollama-qwen3.5-4b   → Qwen3.5 4B (3.4GB, fast, tool calling) — SIMPLE primary
+ *   local/ollama-qwen3.5-0.8b → Qwen3.5 0.8B (1.0GB, ultra-fast) — heartbeat/yes-no
+ *   local/ollama-qwen3.5-9b   → Qwen3.5 9B (6.6GB, stronger) — agentic medium
+ *   local/ollama-qwen3-14b    → Qwen3 14B (legacy, tool calling)
+ *   claude-cli/opus            → Claude Opus 4.6 (subscription) — orchestrator
+ *   claude-cli/sonnet          → Claude Sonnet 4.5 (subscription) — fallback
+ *   codex/gpt-5.3              → GPT-5.3 Codex (subscription, code specialist)
+ *   codex/o3                   → OpenAI o3 (subscription, reasoning specialist)
+ *   deepseek/deepseek-chat     → DeepSeek V3 ($0.14/$0.28 per M tokens)
  *   deepseek/deepseek-reasoner → DeepSeek R1 ($0.55/$2.19 per M tokens)
  */
 
@@ -33,65 +35,60 @@ export const LIONHEART_ROUTING_CONFIG: RoutingConfig = {
   ...DEFAULT_ROUTING_CONFIG,
 
   tiers: {
-    // SIMPLE: greetings, definitions, translations, yes/no questions
-    // → Free local model, fast response, no quota burn
+    // SIMPLE: greetings, definitions, translations, yes/no, heartbeat, summaries
+    // → Qwen 3.5 4B: fast, tool calling, $0 (3.4GB sweet spot)
     SIMPLE: {
-      primary: "local/exo-llama-8b",
+      primary: "local/ollama-qwen3.5-4b",
       fallback: [
-        "local/ollama-qwen3-14b",  // $0 local
-        "claude-cli/sonnet",       // subscription
-        "deepseek/deepseek-chat",  // $0.14/M (last resort)
+        "local/ollama-qwen3.5-0.8b",  // $0 ultra-fast fallback
+        "deepseek/deepseek-chat",      // $0.14/M (last resort)
       ],
     },
 
     // MEDIUM: code tasks, technical questions, multi-step instructions
-    // → Ollama Qwen3 14B handles this well with native tool calling
+    // → Codex GPT for coding
     MEDIUM: {
-      primary: "local/ollama-qwen3-14b",
+      primary: "codex/gpt-5.3",
       fallback: [
-        "codex/gpt-5.3",          // subscription, code specialist
-        "claude-cli/sonnet",       // subscription
-        "deepseek/deepseek-chat",  // $0.14/M
+        "claude-cli/sonnet",           // subscription fallback
+        "local/ollama-qwen3-14b",      // $0 local
+        "deepseek/deepseek-chat",      // $0.14/M
       ],
     },
 
-    // COMPLEX: architecture design, complex analysis, long-context tasks
-    // → Claude Sonnet first, then Codex (subscription) before DeepSeek (paid)
+    // COMPLEX: architecture design, complex analysis, planning, orchestration
+    // → Opus as orchestrator
     COMPLEX: {
-      primary: "claude-cli/sonnet",
+      primary: "claude-cli/opus",
       fallback: [
-        "codex/gpt-5.3",              // subscription — tried before DeepSeek
-        "claude-cli/opus",             // subscription escalation
+        "codex/gpt-5.3",              // subscription — code fallback
+        "claude-cli/sonnet",           // subscription downgrade
         "deepseek/deepseek-chat",      // $0.14/M
       ],
     },
 
     // REASONING: proofs, formal derivation, chain-of-thought, math
-    // → Claude Opus first, then Codex o3 (subscription reasoning) before DeepSeek
     REASONING: {
       primary: "claude-cli/opus",
       fallback: [
         "codex/o3",                    // subscription — OpenAI reasoning model
         "deepseek/deepseek-reasoner",  // $0.55/M
-        "claude-cli/sonnet",           // subscription downgrade
       ],
     },
   },
 
   // Agentic tiers: models with strong tool calling for multi-step tasks
-  // Key: Ollama Qwen3 14B has native OpenAI tool calling (0.971 F1)
-  // Codex GPT-5.3 also supports tool calling via <<<TOOL_CALL>>> protocol
+  // Key: Qwen3.5 has native OpenAI-compatible tool calling
   agenticTiers: {
     SIMPLE: {
-      primary: "local/ollama-qwen3-14b",  // Native tool calling, $0
+      primary: "local/ollama-qwen3.5-4b",  // Native tool calling, $0
       fallback: [
-        "codex/gpt-5.3",              // subscription, tool calling
-        "claude-cli/sonnet",           // subscription
+        "local/ollama-qwen3.5-9b",    // $0 stronger fallback
         "deepseek/deepseek-chat",      // $0.14/M
       ],
     },
     MEDIUM: {
-      primary: "local/ollama-qwen3-14b",  // Strong tool calling for coding
+      primary: "local/ollama-qwen3.5-9b",  // 9B for agentic medium, tool calling
       fallback: [
         "codex/gpt-5.3",              // subscription, code specialist
         "claude-cli/sonnet",           // subscription
@@ -99,10 +96,10 @@ export const LIONHEART_ROUTING_CONFIG: RoutingConfig = {
       ],
     },
     COMPLEX: {
-      primary: "claude-cli/sonnet",
+      primary: "claude-cli/opus",
       fallback: [
-        "codex/gpt-5.3",              // subscription — before DeepSeek
-        "claude-cli/opus",             // subscription escalation
+        "codex/gpt-5.3",              // subscription — code fallback
+        "claude-cli/sonnet",           // subscription downgrade
         "deepseek/deepseek-chat",      // $0.14/M
       ],
     },
@@ -111,8 +108,16 @@ export const LIONHEART_ROUTING_CONFIG: RoutingConfig = {
       fallback: [
         "codex/o3",                    // subscription — reasoning specialist
         "deepseek/deepseek-reasoner",  // $0.55/M
-        "claude-cli/sonnet",           // subscription downgrade
       ],
+    },
+  },
+
+  scoring: {
+    ...DEFAULT_ROUTING_CONFIG.scoring,
+    tierBoundaries: {
+      simpleMedium: 0.0,       // Default — negative scores → SIMPLE, near-zero → ambiguous
+      mediumComplex: 0.30,     // Unchanged
+      complexReasoning: 0.50,  // Unchanged
     },
   },
 
@@ -120,8 +125,8 @@ export const LIONHEART_ROUTING_CONFIG: RoutingConfig = {
     ...DEFAULT_ROUTING_CONFIG.overrides,
     // Lower threshold since local models have small context windows
     maxTokensForceComplex: 8_000,
-    // Default ambiguous to MEDIUM (routes to Ollama, free)
-    ambiguousDefaultTier: "MEDIUM",
+    // Default ambiguous to SIMPLE (routes to Qwen, free)
+    ambiguousDefaultTier: "SIMPLE",
   },
 };
 
@@ -132,9 +137,12 @@ export const LIONHEART_ROUTING_CONFIG: RoutingConfig = {
  */
 export const LIONHEART_MODEL_PRICING = new Map([
   // Local models — $0
+  ["local/ollama-qwen3.5-4b", { inputPrice: 0, outputPrice: 0 }],
+  ["local/ollama-qwen3.5-0.8b", { inputPrice: 0, outputPrice: 0 }],
+  ["local/ollama-qwen3.5-9b", { inputPrice: 0, outputPrice: 0 }],
+  ["local/ollama-qwen3-14b", { inputPrice: 0, outputPrice: 0 }],
   ["local/exo-llama-8b", { inputPrice: 0, outputPrice: 0 }],
   ["local/exo-llama-3b", { inputPrice: 0, outputPrice: 0 }],
-  ["local/ollama-qwen3-14b", { inputPrice: 0, outputPrice: 0 }],
 
   // Claude CLI — subscription, no marginal cost per token
   ["claude-cli/sonnet", { inputPrice: 0, outputPrice: 0 }],

--- a/test/fallback.ts
+++ b/test/fallback.ts
@@ -15,6 +15,7 @@ import type { AddressInfo } from "node:net";
 const modelCalls: string[] = [];
 let failModels: string[] = [];
 let failAllModels = false;
+let failMode: "json" | "sse" | "json200" = "json";
 
 // Mock BlockRun API server
 async function startMockServer(): Promise<{ port: number; close: () => Promise<void> }> {
@@ -34,6 +35,33 @@ async function startMockServer(): Promise<{ port: number; close: () => Promise<v
 
       // Simulate provider error for models in failModels list (or all models)
       if (failAllModels || failModels.includes(model)) {
+        if (failMode === "sse") {
+          console.log(`  [MockAPI] Simulating 200 SSE provider error for ${model}`);
+          res.writeHead(200, { "Content-Type": "text/event-stream" });
+          const limitMsg = "Provider error: service currently unavailable";
+          res.end([
+            `data: ${JSON.stringify({ is_error: true, result: limitMsg, type: "result", subtype: "success" })}`,
+            "",
+            "data: [DONE]",
+            "",
+          ].join("\n"));
+          return;
+        }
+
+        if (failMode === "json200") {
+          console.log(`  [MockAPI] Simulating 200 JSON provider error for ${model}`);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              is_error: true,
+              result: "Provider error: service currently unavailable",
+              type: "result",
+              subtype: "success",
+            }),
+          );
+          return;
+        }
+
         console.log(`  [MockAPI] Simulating billing error for ${model}`);
         res.writeHead(400, { "Content-Type": "application/json" });
         res.end(
@@ -129,6 +157,7 @@ async function runTests() {
     modelCalls.length = 0;
     failModels = [];
     failAllModels = false;
+    failMode = "json";
 
     const res = await fetch(`${proxy.baseUrl}/v1/chat/completions`, {
       method: "POST",
@@ -154,6 +183,7 @@ async function runTests() {
     modelCalls.length = 0;
     failModels = [];
     failAllModels = false;
+    failMode = "json";
 
     const res = await fetch(`${proxy.baseUrl}/v1/chat/completions`, {
       method: "POST",
@@ -175,6 +205,7 @@ async function runTests() {
     modelCalls.length = 0;
     failModels = [reasoningPrimary];
     failAllModels = false;
+    failMode = "json";
 
     const res = await fetch(`${proxy.baseUrl}/v1/chat/completions`, {
       method: "POST",
@@ -199,6 +230,66 @@ async function runTests() {
     reasoningFirstFallback = modelCalls[1] || "";
   }
 
+  // Test 2c: Primary returns 200 SSE limit payload - should fallback
+  {
+    console.log("\n--- Test 2c: Primary 200 SSE limit payload fallback succeeds ---");
+    modelCalls.length = 0;
+    failModels = [reasoningPrimary];
+    failAllModels = false;
+    failMode = "sse";
+
+    const res = await fetch(`${proxy.baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "auto",
+        messages: [{ role: "user", content: reasoningPrompt() }],
+        max_tokens: 50,
+      }),
+    });
+
+    assert(res.ok, `Response OK after 200 SSE fallback: ${res.status}`);
+    const data = (await res.json()) as {
+      model?: string;
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const content = data.choices?.[0]?.message?.content || "";
+    assert(content.startsWith("Response from "), `Response from fallback model: ${content}`);
+    assert(modelCalls.length >= 2, `At least 2 models called: ${modelCalls.join(", ")}`);
+    assert(modelCalls[0] === reasoningPrimary, `First tried primary: ${modelCalls[0]}`);
+    assert(modelCalls[1] !== reasoningPrimary, `Then tried fallback: ${modelCalls[1]}`);
+  }
+
+  // Test 2b: Primary returns 200 JSON limit payload - should fallback
+  {
+    console.log("\n--- Test 2b: Primary 200 JSON limit payload fallback succeeds ---");
+    modelCalls.length = 0;
+    failModels = [reasoningPrimary];
+    failAllModels = false;
+    failMode = "json200";
+
+    const res = await fetch(`${proxy.baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "auto",
+        messages: [{ role: "user", content: reasoningPrompt() }],
+        max_tokens: 50,
+      }),
+    });
+
+    assert(res.ok, `Response OK after 200 JSON fallback: ${res.status}`);
+    const data = (await res.json()) as {
+      model?: string;
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const content = data.choices?.[0]?.message?.content || "";
+    assert(content.startsWith("Response from "), `Response from fallback model: ${content}`);
+    assert(modelCalls.length >= 2, `At least 2 models called: ${modelCalls.join(", ")}`);
+    assert(modelCalls[0] === reasoningPrimary, `First tried primary: ${modelCalls[0]}`);
+    assert(modelCalls[1] !== reasoningPrimary, `Then tried fallback: ${modelCalls[1]}`);
+  }
+
   // Test 3: Primary and first fallback fail - should try second fallback
   {
     console.log("\n--- Test 3: Primary + first fallback fail, second fallback succeeds ---");
@@ -208,6 +299,7 @@ async function runTests() {
       ? [reasoningPrimary, reasoningFirstFallback]
       : [reasoningPrimary];
     failAllModels = false;
+    failMode = "json";
 
     const res = await fetch(`${proxy.baseUrl}/v1/chat/completions`, {
       method: "POST",
@@ -232,6 +324,7 @@ async function runTests() {
     modelCalls.length = 0;
     failModels = [];
     failAllModels = true;
+    failMode = "json";
 
     const res = await fetch(`${proxy.baseUrl}/v1/chat/completions`, {
       method: "POST",
@@ -263,6 +356,7 @@ async function runTests() {
     modelCalls.length = 0;
     failModels = ["openai/gpt-4o"];
     failAllModels = false;
+    failMode = "json";
 
     const res = await fetch(`${proxy.baseUrl}/v1/chat/completions`, {
       method: "POST",
@@ -293,6 +387,7 @@ async function runTests() {
     modelCalls.length = 0;
     failModels = [];
     failAllModels = false;
+    failMode = "json";
 
     const res = await fetch(`${proxy.baseUrl}/v1/chat/completions`, {
       method: "POST",
@@ -318,6 +413,7 @@ async function runTests() {
     modelCalls.length = 0;
     failModels = ["deepseek/deepseek-chat"];
     failAllModels = false;
+    failMode = "json";
 
     const res = await fetch(`${proxy.baseUrl}/v1/chat/completions`, {
       method: "POST",
@@ -341,6 +437,36 @@ async function runTests() {
       `Primary canonical model used: ${modelCalls[0]}`,
     );
     assert(modelCalls[1] === "nvidia/gpt-oss-120b", `Fallback model used: ${modelCalls[1]}`);
+  }
+
+  // Test 8: Explicit model with 200 SSE provider error payload falls back to free model
+  {
+    console.log("\n--- Test 8: Explicit model 200 SSE fallback to free model ---");
+    modelCalls.length = 0;
+    failModels = ["openai/gpt-4o"];
+    failAllModels = false;
+    failMode = "sse";
+
+    const res = await fetch(`${proxy.baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "openai/gpt-4o",
+        messages: [{ role: "user", content: uniqueMessage("Hello") }],
+        max_tokens: 50,
+      }),
+    });
+
+    assert(res.ok, `Explicit model 200 SSE fallback succeeds: ${res.status}`);
+    assert(
+      modelCalls.length === 2,
+      `2 models called (primary + free fallback): ${modelCalls.join(", ")}`,
+    );
+    assert(modelCalls[0] === "openai/gpt-4o", `Primary explicit model first: ${modelCalls[0]}`);
+    assert(
+      modelCalls[1] === "nvidia/gpt-oss-120b",
+      `Then fell back to free model: ${modelCalls[1]}`,
+    );
   }
 
   // Cleanup

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -2,7 +2,7 @@
  * Integration test setup — programmatically starts ClawRouter proxy.
  *
  * Shared across all integration test files via beforeAll/afterAll.
- * Starts the proxy on port 8402, waits for /health to return 200,
+ * Starts the proxy on an ephemeral localhost port, waits for /health to return 200,
  * and caches the handle so multiple test files share one instance.
  */
 
@@ -10,14 +10,14 @@ import { startProxy } from "../../src/proxy.js";
 import { resolveOrGenerateWalletKey } from "../../src/auth.js";
 import type { ProxyHandle } from "../../src/proxy.js";
 
-const TEST_PORT = 8402;
+const TEST_PORT = 0;
 const HEALTH_POLL_INTERVAL_MS = 200;
 const HEALTH_TIMEOUT_MS = 5_000;
 
 let proxyHandle: ProxyHandle | undefined;
 
 /**
- * Start the test proxy on port 8402.
+ * Start the test proxy on an ephemeral localhost port.
  * Polls /health until it returns 200 (up to 5s), then returns the handle.
  * Reuses an existing handle if already started.
  */
@@ -57,7 +57,7 @@ export async function stopTestProxy(): Promise<void> {
 }
 
 /**
- * Get the base URL of the running test proxy (e.g. http://127.0.0.1:8402).
+ * Get the base URL of the running test proxy.
  * Throws if the proxy has not been started.
  */
 export function getTestProxyUrl(): string {


### PR DESCRIPTION
## Summary
- sync the Lionroot fork branch onto current upstream `main`
- preserve Lionroot routing/fallback behavior on top of upstream
- isolate integration tests from the always-on local gateway by using an ephemeral test port

## Included maintenance work
- hardened degraded-provider fallback detection
- updated Lionroot routing defaults and fallback chains
- fixed the `/debug` integration harness to avoid reusing the live proxy on port 8402

## Validation
- `npm test` → 304 passed, 3 skipped
- `npm run build`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented comprehensive upstream error classification system to better detect rate limits, billing failures, and authentication issues.
  * Enhanced streaming response handling to properly parse and format provider errors into standardized formats.
  * Introduced Lionheart routing configuration with per-model pricing for improved model selection and cost optimization.

* **Tests**
  * Expanded test coverage for degraded response detection across multiple payload formats and scenarios.
  * Added fallback validation for rate-limited and streaming provider errors.

* **Documentation**
  * Added project overview and structure documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->