### PR TITLE
fix: Timeout (AbortError) triggers fallback chain instead of skipping

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3423,17 +3423,34 @@ async function proxyRequest(
 
       console.log(`[ClawRouter] Trying model ${i + 1}/${modelsToTry.length}: ${tryModel}`);
 
-      const result = await tryModelRequest(
-        upstreamUrl,
-        req.method ?? "POST",
-        headers,
-        body,
-        tryModel,
-        maxTokens,
-        payFetch,
-        balanceMonitor,
-        controller.signal,
-      );
+      let result: ModelRequestResult;
+      try {
+        result = await tryModelRequest(
+          upstreamUrl,
+          req.method ?? "POST",
+          headers,
+          body,
+          tryModel,
+          maxTokens,
+          payFetch,
+          balanceMonitor,
+          controller.signal,
+        );
+      } catch (err) {
+        // Timeout (AbortError) should trigger fallback to next model, not exit the loop
+        if (err instanceof Error && err.name === "AbortError") {
+          console.log(`[ClawRouter] Timeout on ${tryModel}, trying fallback...`);
+          lastError = {
+            body: `Request timed out after ${timeoutMs}ms`,
+            status: 408,
+          };
+          if (!isLastAttempt) {
+            continue;
+          }
+        }
+        // Re-throw other errors to be handled by outer catch
+        throw err;
+      }
 
       if (result.success && result.response) {
         upstream = result.response;


### PR DESCRIPTION
## Summary

When an LLM request hits the hard timeout (`AbortError`), the extension was throwing an error **outside** the fallback `for` loop, causing the full fallback model chain to be silently skipped. No fallback model was ever tried on timeout — only on provider errors (4xx/5xx).

## Fix

- Wrap `tryModelRequest` in try/catch inside the fallback loop
- On AbortError (timeout), log warning and continue to next model
- This fixes the issue where timeouts would exit the fallback loop entirely
- Previously, only provider errors (4xx/5xx) triggered fallback; now timeouts do too

## Changes

- `src/proxy.ts`: Added try/catch around `tryModelRequest` call inside the fallback for loop
- On AbortError, sets `lastError` with timeout message and continues to next model if not last attempt

Fixes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling to gracefully fall back to alternative models instead of immediately failing when a request times out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->