### PR TITLE
fix: timeout (AbortError) triggers fallback to next model in chain

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3322,9 +3322,11 @@ async function proxyRequest(
   });
 
   // --- Request timeout ---
+  // Timeout is applied per-model-attempt (not per-request) so that AbortError
+  // from a slow primary model can trigger fallback to the next model in the chain.
   const timeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  let controller = new AbortController();
+  let timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     // --- Build fallback chain ---
@@ -3423,17 +3425,38 @@ async function proxyRequest(
 
       console.log(`[ClawRouter] Trying model ${i + 1}/${modelsToTry.length}: ${tryModel}`);
 
-      const result = await tryModelRequest(
-        upstreamUrl,
-        req.method ?? "POST",
-        headers,
-        body,
-        tryModel,
-        maxTokens,
-        payFetch,
-        balanceMonitor,
-        controller.signal,
-      );
+      // Reset per-attempt timeout so each model gets the full timeout window
+      clearTimeout(timeoutId);
+      controller = new AbortController();
+      timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+      let result: ModelRequestResult;
+      try {
+        result = await tryModelRequest(
+          upstreamUrl,
+          req.method ?? "POST",
+          headers,
+          body,
+          tryModel,
+          maxTokens,
+          payFetch,
+          balanceMonitor,
+          controller.signal,
+        );
+      } catch (err) {
+        // Timeout (AbortError) should trigger fallback, not hard failure
+        if (err instanceof Error && err.name === "AbortError") {
+          if (!isLastAttempt) {
+            console.log(
+              `[ClawRouter] Model ${tryModel} timed out after ${timeoutMs}ms, trying fallback`,
+            );
+            continue;
+          }
+          // Last attempt — no more fallbacks, throw timeout error
+          throw new Error(`Request timed out after ${timeoutMs}ms (all ${modelsToTry.length} model(s) exhausted)`, { cause: err });
+        }
+        throw err;
+      }
 
       if (result.success && result.response) {
         upstream = result.response;


### PR DESCRIPTION
## Problem

When a model request times out (`AbortError`), the entire fallback chain is silently skipped. The error propagates to the outer `catch` block and throws immediately — no fallback model is ever tried on timeout.

This means users with multi-model fallback chains configured get hard failures on timeout instead of automatic model failover, defeating the purpose of the fallback configuration.

**Impact:** 7+ timeout failures observed in a single session, all skipping the fallback chain (#95).

## Root Cause

The `AbortController` and timeout were created **once** before the fallback `for` loop (line ~3326). When the timeout fired, `AbortError` propagated through `tryModelRequest` → outer `catch` → `throw`, bypassing the loop entirely.

For comparison, provider errors (4xx/5xx) already correctly trigger `continue` to the next model inside the loop.

## Fix

1. **Per-attempt timeout:** The `AbortController` is now reset before each `tryModelRequest` call, giving each model the full timeout window.

2. **AbortError inside the loop:** `tryModelRequest` is wrapped in a try-catch within the fallback loop. `AbortError` on non-last attempts triggers `continue` (fallback). On the last attempt, it throws with a descriptive error including how many models were exhausted.

3. **Outer catch preserved:** The existing outer `AbortError` handler remains as a safety net for edge cases.

## Changes

```
src/proxy.ts | 36 insertions, 13 deletions
```

- Move `AbortController`/`setTimeout` reset inside the `for` loop (before each `tryModelRequest`)
- Wrap `tryModelRequest` in try-catch for `AbortError`
- Non-last attempt: log timeout + `continue` to next model
- Last attempt: throw with model count in error message

## Testing

All existing tests pass (331 passed, 3 skipped):

```
npm test
✓ 22 test files passed | 1 skipped
✓ 331 tests passed | 3 skipped
```

TypeScript compiles cleanly (`tsc --noEmit` — no errors).

## Behavior After Fix

| Scenario | Before | After |
|---|---|---|
| Primary model times out, fallback available | ❌ Hard error | ✅ Falls back to next model |
| All models time out | ❌ Error from primary only | ✅ Error with "all N model(s) exhausted" |
| Single model (no fallback) times out | ❌ Error | ❌ Error (same, correct behavior) |
| Provider error (4xx/5xx) | ✅ Falls back | ✅ Falls back (unchanged) |

Fixes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request timeout handling to ensure each model receives its own timeout window, enhancing reliability and resilience when models respond slowly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->