### PR TITLE
fix: use actual token counts for /stats cost calculation instead of estimates

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -22,6 +22,8 @@ export type UsageEntry = {
   latencyMs: number;
   /** Input (prompt) tokens reported by the provider */
   inputTokens?: number;
+  /** Output (completion) tokens reported by the provider */
+  outputTokens?: number;
   /** Partner service ID (e.g., "x_users_lookup") — only set for partner API calls */
   partnerId?: string;
   /** Partner service name (e.g., "AttentionVC") — only set for partner API calls */

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2256,6 +2256,7 @@ async function proxyRequest(
   let balanceFallbackNotice: string | undefined;
   let accumulatedContent = ""; // For session journal event extraction
   let responseInputTokens: number | undefined;
+  let responseOutputTokens: number | undefined;
   const isChatCompletion = req.url?.includes("/chat/completions");
 
   // Extract session ID early for journal operations (header-only at this point)
@@ -3664,6 +3665,7 @@ async function proxyRequest(
           if (rsp.usage && typeof rsp.usage === "object") {
             const u = rsp.usage as Record<string, unknown>;
             if (typeof u.prompt_tokens === "number") responseInputTokens = u.prompt_tokens;
+            if (typeof u.completion_tokens === "number") responseOutputTokens = u.completion_tokens;
           }
 
           // Build base chunk structure (reused for all chunks)
@@ -3882,6 +3884,8 @@ async function proxyRequest(
         if (rspJson.usage && typeof rspJson.usage === "object") {
           if (typeof rspJson.usage.prompt_tokens === "number")
             responseInputTokens = rspJson.usage.prompt_tokens;
+          if (typeof rspJson.usage.completion_tokens === "number")
+            responseOutputTokens = rspJson.usage.completion_tokens;
         }
       } catch {
         // Ignore parse errors - journal just won't have content for this response
@@ -3931,32 +3935,33 @@ async function proxyRequest(
   }
 
   // --- Usage logging (fire-and-forget) ---
-  // Note: Recalculate cost using full body length (not just system+user message)
-  // and apply 20% buffer to match actual x402 payment (see estimateAmount())
+  // Note: Use actual token counts from API response when available,
+  // fall back to estimates. Log actual cost without 20% buffer (the buffer
+  // is only needed for pre-payment estimation in estimateAmount()).
   // Log ALL requests: both auto-routed (routingDecision set) and direct model picks
   const logModel = routingDecision?.model ?? modelId;
   if (logModel) {
-    // Use full body length for accurate cost (matches x402 payment estimation)
-    const estimatedInputTokens = Math.ceil(body.length / 4);
+    // Use actual token counts when available, fall back to estimates
+    const actualInputTokens = responseInputTokens ?? Math.ceil(body.length / 4);
+    const actualOutputTokens = responseOutputTokens ?? maxTokens;
+
     const accurateCosts = calculateModelCost(
       logModel,
       routerOpts.modelPricing,
-      estimatedInputTokens,
-      maxTokens,
+      actualInputTokens,
+      actualOutputTokens,
       routingProfile ?? undefined,
     );
-    // Apply 20% buffer for cost estimation accuracy
-    const costWithBuffer = accurateCosts.costEstimate * 1.2;
-    const baselineWithBuffer = accurateCosts.baselineCost * 1.2;
     const entry: UsageEntry = {
       timestamp: new Date().toISOString(),
       model: logModel,
       tier: routingDecision?.tier ?? "DIRECT",
-      cost: costWithBuffer,
-      baselineCost: baselineWithBuffer,
+      cost: accurateCosts.costEstimate,
+      baselineCost: accurateCosts.baselineCost,
       savings: accurateCosts.savings,
       latencyMs: Date.now() - startTime,
       ...(responseInputTokens !== undefined && { inputTokens: responseInputTokens }),
+      ...(responseOutputTokens !== undefined && { outputTokens: responseOutputTokens }),
     };
     logUsage(entry).catch(() => {});
   }


### PR DESCRIPTION
## Problem

Fixes #36

The `/stats` endpoint overstates costs by ~2.5x compared to on-chain charges. Two compounding issues:

### 1. `maxTokens` used instead of actual output tokens
`calculateModelCost()` receives `maxTokens` (the maximum *allowed* output, e.g. 4096) rather than the actual `completion_tokens` from the response. A response generating 200 tokens is costed as if 4096 were produced.

### 2. 20% buffer applied to logged cost
The pre-payment estimation correctly applies a 1.2x buffer (you overpay slightly because exact cost is unknown upfront). However, this same buffer was also applied to the **logged cost** shown in `/stats`, inflating displayed expenses.

## Fix

### Changes in `src/proxy.ts`:
- Capture `completion_tokens` from upstream responses (both streaming and non-streaming paths) into a new `responseOutputTokens` variable
- Use actual token counts (`responseInputTokens`, `responseOutputTokens`) for cost calculation when available, falling back to estimates only when the upstream provider doesn't return usage data
- Remove the 1.2x buffer from the logged `UsageEntry` — log actual cost, not the pre-payment estimate

### Changes in `src/logger.ts`:
- Add optional `outputTokens` field to `UsageEntry` type for richer `/stats` reporting

### What was NOT changed:
- `estimateAmount()` — pre-payment 20% buffer is correct and stays
- `BALANCE_CHECK_BUFFER` (1.5x) — balance checking buffer is correct and stays
- `calculateModelCost()` — function is correct, it was just receiving wrong inputs

## Testing
- All 331 tests pass, 3 skipped (pre-existing)
- TypeScript compiles cleanly (`tsc --noEmit`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added output token tracking to provide more detailed usage metrics alongside input tokens.

* **Bug Fixes**
  * Improved usage and cost calculations to use actual token counts from provider responses instead of estimates, removing inaccurate approximation buffers for greater precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->