### PR TITLE
feat: add Novita AI as a direct LLM provider

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import type {
   OpenClawPluginCommandDefinition,
 } from "./types.js";
 import { blockrunProvider, setActiveProxy } from "./provider.js";
+import { novitaProvider, NOVITA_MODELS } from "./novita-provider.js";
 import { startProxy, getProxyPort } from "./proxy.js";
 import {
   resolveOrGenerateWalletKey,
@@ -973,6 +974,9 @@ const plugin: OpenClawPluginDefinition = {
 
     // Register BlockRun as a provider (sync — available immediately)
     api.registerProvider(blockrunProvider);
+
+    // Register Novita AI as a provider (direct API access with NOVITA_API_KEY)
+    api.registerProvider(novitaProvider);
 
     // Inject models config into OpenClaw config file
     // This persists the config so models are recognized on restart

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -41,4 +41,22 @@ describe("resolveModelAlias", () => {
     expect(resolveModelAlias("blockrun/xai/grok-code-fast-1")).toBe("deepseek/deepseek-chat");
     expect(resolveModelAlias("grok-code-fast-1")).toBe("deepseek/deepseek-chat");
   });
+
+  it("resolves Novita AI aliases", () => {
+    expect(resolveModelAlias("novita")).toBe("novita/kimi-k2.5");
+    expect(resolveModelAlias("novita-kimi")).toBe("novita/kimi-k2.5");
+    expect(resolveModelAlias("novita-glm")).toBe("novita/glm-5");
+    expect(resolveModelAlias("novita-minimax")).toBe("novita/minimax-m2.5");
+  });
+
+  it("passes through novita/ model IDs unchanged", () => {
+    expect(resolveModelAlias("novita/kimi-k2.5")).toBe("novita/kimi-k2.5");
+    expect(resolveModelAlias("novita/glm-5")).toBe("novita/glm-5");
+    expect(resolveModelAlias("novita/minimax-m2.5")).toBe("novita/minimax-m2.5");
+  });
+
+  it("resolves Novita aliases with blockrun/ prefix", () => {
+    expect(resolveModelAlias("blockrun/novita-kimi")).toBe("novita/kimi-k2.5");
+    expect(resolveModelAlias("blockrun/novita")).toBe("novita/kimi-k2.5");
+  });
 });

--- a/src/models.ts
+++ b/src/models.ts
@@ -90,6 +90,12 @@ export const MODEL_ALIASES: Record<string, string> = {
   "glm-5": "zai/glm-5",
   "glm-5-turbo": "zai/glm-5-turbo",
 
+  // Novita AI
+  novita: "novita/kimi-k2.5",
+  "novita-kimi": "novita/kimi-k2.5",
+  "novita-glm": "novita/glm-5",
+  "novita-minimax": "novita/minimax-m2.5",
+
   // Routing profile aliases (common variations)
   "auto-router": "auto",
   router: "auto",
@@ -716,6 +722,43 @@ export const BLOCKRUN_MODELS: BlockRunModel[] = [
     outputPrice: 4.0,
     contextWindow: 200000,
     maxOutput: 128000,
+    toolCalling: true,
+  },
+
+  // Novita AI — direct API access via NOVITA_API_KEY (bypasses x402)
+  {
+    id: "novita/kimi-k2.5",
+    name: "Novita Kimi K2.5",
+    version: "k2.5",
+    inputPrice: 0.6,
+    outputPrice: 3.0,
+    contextWindow: 262144,
+    maxOutput: 262144,
+    reasoning: true,
+    vision: true,
+    agentic: true,
+    toolCalling: true,
+  },
+  {
+    id: "novita/glm-5",
+    name: "Novita GLM-5",
+    version: "5",
+    inputPrice: 1.0,
+    outputPrice: 3.2,
+    contextWindow: 202800,
+    maxOutput: 131072,
+    reasoning: true,
+    toolCalling: true,
+  },
+  {
+    id: "novita/minimax-m2.5",
+    name: "Novita MiniMax M2.5",
+    version: "m2.5",
+    inputPrice: 0.3,
+    outputPrice: 1.2,
+    contextWindow: 204800,
+    maxOutput: 131100,
+    reasoning: true,
     toolCalling: true,
   },
 ];

--- a/src/novita-provider.ts
+++ b/src/novita-provider.ts
@@ -1,0 +1,161 @@
+/**
+ * Novita AI Provider Plugin for OpenClaw
+ *
+ * Registers Novita AI as an LLM provider with direct API access.
+ * Uses OpenAI-compatible endpoint at https://api.novita.ai/openai
+ *
+ * Users provide their own NOVITA_API_KEY for authentication.
+ */
+
+import type { ProviderPlugin, ModelDefinitionConfig, ModelProviderConfig } from "./types.js";
+
+/**
+ * Novita AI model definitions.
+ * Model IDs and pricing from Novita AI catalog (CLAUDE.md).
+ */
+type NovitaModel = {
+  id: string;
+  name: string;
+  inputPrice: number;
+  outputPrice: number;
+  contextWindow: number;
+  maxOutput: number;
+  reasoning?: boolean;
+  vision?: boolean;
+  agentic?: boolean;
+  toolCalling?: boolean;
+};
+
+const NOVITA_MODEL_DEFS: NovitaModel[] = [
+  {
+    id: "moonshotai/kimi-k2.5",
+    name: "Kimi K2.5 (Novita)",
+    inputPrice: 0.6,
+    outputPrice: 3.0,
+    contextWindow: 262144,
+    maxOutput: 262144,
+    reasoning: true,
+    vision: true,
+    agentic: true,
+    toolCalling: true,
+  },
+  {
+    id: "zai-org/glm-5",
+    name: "GLM-5 (Novita)",
+    inputPrice: 1.0,
+    outputPrice: 3.2,
+    contextWindow: 202800,
+    maxOutput: 131072,
+    reasoning: true,
+    toolCalling: true,
+  },
+  {
+    id: "minimax/minimax-m2.5",
+    name: "MiniMax M2.5 (Novita)",
+    inputPrice: 0.3,
+    outputPrice: 1.2,
+    contextWindow: 204800,
+    maxOutput: 131100,
+    reasoning: true,
+    toolCalling: true,
+  },
+];
+
+/**
+ * Convert Novita model definitions to OpenClaw ModelDefinitionConfig format.
+ */
+function toOpenClawModel(m: NovitaModel): ModelDefinitionConfig {
+  return {
+    id: m.id,
+    name: m.name,
+    api: "openai-completions" as const,
+    reasoning: m.reasoning ?? false,
+    input: m.vision ? ["text", "image"] : ["text"],
+    cost: {
+      input: m.inputPrice,
+      output: m.outputPrice,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow: m.contextWindow,
+    maxTokens: m.maxOutput,
+  };
+}
+
+/**
+ * All Novita models in OpenClaw format.
+ */
+export const NOVITA_MODELS: ModelDefinitionConfig[] = NOVITA_MODEL_DEFS.map(toOpenClawModel);
+
+/**
+ * Build a ModelProviderConfig for Novita AI.
+ */
+export function buildNovitaProviderModels(apiKey: string): ModelProviderConfig {
+  return {
+    baseUrl: "https://api.novita.ai/openai/v1",
+    api: "openai-completions" as const,
+    apiKey,
+    models: NOVITA_MODELS,
+  };
+}
+
+/**
+ * Novita AI provider plugin definition.
+ */
+export const novitaProvider: ProviderPlugin = {
+  id: "novita",
+  label: "Novita AI",
+  docsPath: "https://novita.ai/docs",
+  aliases: ["novita"],
+  envVars: ["NOVITA_API_KEY"],
+
+  get models() {
+    return {
+      baseUrl: "https://api.novita.ai/openai/v1",
+      api: "openai-completions" as const,
+      models: NOVITA_MODELS,
+    };
+  },
+
+  auth: [
+    {
+      id: "api_key",
+      label: "API Key",
+      hint: "Get your API key from https://novita.ai/dashboard",
+      kind: "api_key",
+      run: async (ctx) => {
+        const apiKey = await ctx.prompter.text({
+          message: "Enter your Novita API key:",
+          validate: (value) => {
+            if (!value || value.trim().length === 0) {
+              return "API key is required";
+            }
+            return undefined;
+          },
+        });
+
+        if (typeof apiKey !== "string") {
+          return { profiles: [] };
+        }
+
+        return {
+          profiles: [
+            {
+              profileId: "default",
+              credential: {
+                type: "api_key",
+                apiKey: apiKey.trim(),
+              },
+            },
+          ],
+          defaultModel: "moonshotai/kimi-k2.5",
+          notes: ["Novita AI models use pay-per-token pricing via your Novita account."],
+        };
+      },
+    },
+  ],
+
+  formatApiKey: (cred) => {
+    return cred.apiKey ?? "";
+  },
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -93,6 +93,14 @@ import { SessionJournal } from "./journal.js";
 
 const BLOCKRUN_API = "https://blockrun.ai/api";
 const BLOCKRUN_SOLANA_API = "https://sol.blockrun.ai/api";
+const NOVITA_API = "https://api.novita.ai/openai";
+
+/** Maps ClawRouter novita/ model IDs to Novita AI's native model IDs. */
+const NOVITA_MODEL_IDS: Record<string, string> = {
+  "novita/kimi-k2.5": "moonshotai/kimi-k2.5",
+  "novita/glm-5": "zai-org/glm-5",
+  "novita/minimax-m2.5": "minimax/minimax-m2.5",
+};
 const IMAGE_DIR = join(homedir(), ".openclaw", "blockrun", "images");
 // Routing profile models - virtual models that trigger intelligent routing
 const AUTO_MODEL = "blockrun/auto";
@@ -2315,6 +2323,60 @@ async function tryModelRequest(
     // If body isn't valid JSON, use as-is
   }
 
+  // Novita AI direct bypass: route novita/ models to api.novita.ai without x402
+  if (modelId.startsWith("novita/")) {
+    const novitaApiKey = process.env.NOVITA_API_KEY;
+    if (!novitaApiKey) {
+      return {
+        success: false,
+        errorBody: JSON.stringify({ error: { message: "NOVITA_API_KEY not set" } }),
+        errorStatus: 401,
+        isProviderError: false,
+        errorCategory: "auth_failure",
+      };
+    }
+    try {
+      // Remap model ID to Novita's native ID (e.g., novita/kimi-k2.5 → moonshotai/kimi-k2.5)
+      const nativeModelId = NOVITA_MODEL_IDS[modelId] ?? modelId.replace("novita/", "");
+      let novitaBody = requestBody;
+      try {
+        const bodyParsed = JSON.parse(requestBody.toString()) as Record<string, unknown>;
+        bodyParsed.model = nativeModelId;
+        novitaBody = Buffer.from(JSON.stringify(bodyParsed));
+      } catch {
+        // use requestBody as-is
+      }
+      const novitaUrl = `${NOVITA_API}/v1/chat/completions`;
+      const response = await fetch(novitaUrl, {
+        method,
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${novitaApiKey}` },
+        body: novitaBody.length > 0 ? new Uint8Array(novitaBody) : undefined,
+        signal,
+      });
+      if (response.status !== 200) {
+        const errorBodyChunks = await readBodyWithTimeout(response.body, ERROR_BODY_READ_TIMEOUT_MS);
+        const errorBody = Buffer.concat(errorBodyChunks).toString();
+        const category = categorizeError(response.status, errorBody);
+        return {
+          success: false,
+          errorBody,
+          errorStatus: response.status,
+          isProviderError: category !== null,
+          errorCategory: category ?? undefined,
+        };
+      }
+      return { success: true, response };
+    } catch (err) {
+      return {
+        success: false,
+        errorBody: String(err),
+        errorStatus: 500,
+        isProviderError: true,
+        errorCategory: "server_error",
+      };
+    }
+  }
+
   try {
     const response = await payFetch(upstreamUrl, {
       method,
@@ -3413,8 +3475,10 @@ async function proxyRequest(
   let estimatedCostMicros: bigint | undefined;
   // Use `let` so the balance-fallback path can update this when modelId is switched to FREE_MODEL.
   let isFreeModel = modelId === FREE_MODEL;
+  // Novita models use NOVITA_API_KEY directly — skip x402 balance check
+  const isNovitaModel = modelId.startsWith("novita/");
 
-  if (modelId && !options.skipBalanceCheck && !isFreeModel) {
+  if (modelId && !options.skipBalanceCheck && !isFreeModel && !isNovitaModel) {
     const estimated = estimateAmount(modelId, body.length, maxTokens);
     if (estimated) {
       estimatedCostMicros = BigInt(estimated);


### PR DESCRIPTION
## Summary

Adds [Novita AI](https://novita.ai) as a direct LLM provider alongside the existing BlockRun/x402 routing. When `NOVITA_API_KEY` is set, users can select Novita models without needing a BlockRun wallet funded with USDC.

**Models added** (3):
| Model ID | Native ID | Context | Max Output | Pricing |
|---|---|---|---|---|
| `novita/kimi-k2.5` | `moonshotai/kimi-k2.5` | 262,144 | 262,144 | $0.6/$3.0 per M |
| `novita/glm-5` | `zai-org/glm-5` | 202,800 | 131,072 | $1.0/$3.2 per M |
| `novita/minimax-m2.5` | `minimax/minimax-m2.5` | 204,800 | 131,100 | $0.3/$1.2 per M |

**Aliases**: `novita` → `novita/kimi-k2.5`, `novita-kimi`, `novita-glm`, `novita-minimax`

## Changes

- **`src/models.ts`**: Add 3 Novita model definitions + 4 aliases. Models appear in `/v1/models` and are selectable via `/model novita/kimi-k2.5` or `/model novita`.
- **`src/proxy.ts`**: Novita bypass in `tryModelRequest` — detects `novita/` prefix, maps to Novita's native model ID, calls `https://api.novita.ai/openai/v1/chat/completions` with `Authorization: Bearer $NOVITA_API_KEY` (no x402 payment). Also skips the BlockRun wallet balance pre-check for Novita models.
- **`src/models.test.ts`**: Tests for alias resolution and passthrough of Novita model IDs.

## How it works

```
User: /model novita/kimi-k2.5
  → resolveModelAlias("novita/kimi-k2.5") → "novita/kimi-k2.5"
  → balance check skipped (isNovitaModel = true)
  → tryModelRequest detects novita/ prefix
  → remaps model: "novita/kimi-k2.5" → "moonshotai/kimi-k2.5"
  → POST https://api.novita.ai/openai/v1/chat/completions
     Authorization: Bearer $NOVITA_API_KEY
  → response streamed back normally
  → if Novita fails → fallback to nvidia/gpt-oss-120b (free)
```

## Configuration

```bash
export NOVITA_API_KEY=your_novita_api_key
```

No other configuration needed. If `NOVITA_API_KEY` is not set and a `novita/` model is requested, the proxy returns a 401 and falls back to the free model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Novita AI provider integration with three models: Kimi K2.5, GLM-5, and MiniMax M2.5.
  * Added convenient model aliases (`novita`, `novita-kimi`, `novita-glm`, `novita-minimax`) for quick access.
  * Models include capabilities such as tool calling, vision, reasoning, and agentic features.

* **Tests**
  * Added comprehensive test coverage for model alias resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->