### PR TITLE
fix: always restore OpenClaw credentials after plugin install

### DIFF
--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -269,13 +269,11 @@ fi
 echo "→ Installing ClawRouter..."
 openclaw plugins install @blockrun/clawrouter
 
-# Restore credentials if they were lost during plugin install
+# Restore credentials after plugin install (always restore to preserve user's channels)
 if [ -n "$CREDS_BACKUP" ] && [ -d "$CREDS_BACKUP" ]; then
-  if [ ! -d "$CREDS_DIR" ] || [ -z "$(ls -A "$CREDS_DIR" 2>/dev/null)" ]; then
-    mkdir -p "$CREDS_DIR"
-    cp -a "$CREDS_BACKUP/"* "$CREDS_DIR/"
-    echo "  ✓ Restored OpenClaw credentials (channels preserved)"
-  fi
+  mkdir -p "$CREDS_DIR"
+  cp -a "$CREDS_BACKUP/"* "$CREDS_DIR/"
+  echo "  ✓ Restored OpenClaw credentials (channels preserved)"
   rm -rf "$(dirname "$CREDS_BACKUP")"
 fi
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -182,13 +182,11 @@ fi
 echo "→ Installing latest ClawRouter..."
 openclaw plugins install @blockrun/clawrouter
 
-# Restore credentials if they were lost during plugin install
+# Restore credentials after plugin install (always restore to preserve user's channels)
 if [ -n "$CREDS_BACKUP" ] && [ -d "$CREDS_BACKUP" ]; then
-  if [ ! -d "$CREDS_DIR" ] || [ -z "$(ls -A "$CREDS_DIR" 2>/dev/null)" ]; then
-    mkdir -p "$CREDS_DIR"
-    cp -a "$CREDS_BACKUP/"* "$CREDS_DIR/"
-    echo "  ✓ Restored OpenClaw credentials (channels preserved)"
-  fi
+  mkdir -p "$CREDS_DIR"
+  cp -a "$CREDS_BACKUP/"* "$CREDS_DIR/"
+  echo "  ✓ Restored OpenClaw credentials (channels preserved)"
   rm -rf "$(dirname "$CREDS_BACKUP")"
 fi
 


### PR DESCRIPTION
## Summary

- Fix credentials restore logic in `reinstall.sh` and `update.sh` to **always** restore OpenClaw channel credentials (WhatsApp, Telegram, etc.) after `openclaw plugins install`, rather than only restoring when the credentials directory is missing or empty

## Problem

When `openclaw plugins install @blockrun/clawrouter` runs, it modifies `~/.openclaw/credentials` where channel configurations are stored. The previous restore logic only ran if the credentials directory was **missing or empty** after install:

```bash
# OLD — only restores if directory is missing OR empty
if [ ! -d "$CREDS_DIR" ] || [ -z "$(ls -A "$CREDS_DIR" 2>/dev/null)" ]; then
    cp -a "$CREDS_BACKUP/"* "$CREDS_DIR/"
}
```

If the install wrote new content to the directory (not empty, just different from the user's original), the condition evaluated to false and the user's channel credentials were silently lost. This caused `openclaw` to show no channels.

## Fix

Always restore from the backup after plugin install:

```bash
# NEW — always restore from backup
if [ -n "$CREDS_BACKUP" ] && [ -d "$CREDS_BACKUP" ]; then
    mkdir -p "$CREDS_DIR"
    cp -a "$CREDS_BACKUP/"* "$CREDS_DIR/"
}
```

## Test plan

- [ ] Run `update.sh` or `reinstall.sh` with existing OpenClaw channel credentials
- [ ] Verify channels are still visible via `openclaw` CLI after install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential restoration reliability during installation and update operations to ensure user channel configurations are consistently preserved across operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->