### PR TITLE
fix(plugin): wire up pluginConfig.walletKey declared in configSchema

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -215,7 +215,7 @@ async function generateAndSaveWallet(): Promise<{
 export type WalletResolution = {
   key: string;
   address: string;
-  source: "saved" | "env" | "generated";
+  source: "saved" | "env" | "config" | "generated";
   mnemonic?: string;
   solanaPrivateKeyBytes?: Uint8Array;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import {
   WALLET_FILE,
   MNEMONIC_FILE,
 } from "./auth.js";
+import type { WalletResolution } from "./auth.js";
 import type { RoutingConfig } from "./router/index.js";
 import { BalanceMonitor } from "./balance.js";
 import {
@@ -532,8 +533,18 @@ let activeProxyHandle: Awaited<ReturnType<typeof startProxy>> | null = null;
  * treating activate() as an alias (def.register ?? def.activate).
  */
 async function startProxyInBackground(api: OpenClawPluginApi): Promise<void> {
-  // Resolve wallet key: saved file → env var → auto-generate
-  const wallet = await resolveOrGenerateWalletKey();
+  // Resolve wallet key: plugin config → saved file → env var → auto-generate.
+  // pluginConfig.walletKey is declared in openclaw.plugin.json configSchema but
+  // was previously never read here — that was a bug.
+  const configKey = api.pluginConfig?.walletKey as string | undefined;
+  let wallet: WalletResolution;
+
+  if (typeof configKey === "string" && configKey.startsWith("0x") && configKey.length === 66) {
+    const account = privateKeyToAccount(configKey as `0x${string}`);
+    wallet = { key: configKey, address: account.address, source: "config" };
+  } else {
+    wallet = await resolveOrGenerateWalletKey();
+  }
 
   // Log wallet source
   if (wallet.source === "generated") {
@@ -545,6 +556,8 @@ async function startProxyInBackground(api: OpenClawPluginApi): Promise<void> {
     api.logger.warn(`════════════════════════════════════════════════`);
   } else if (wallet.source === "saved") {
     api.logger.info(`Using saved wallet: ${wallet.address}`);
+  } else if (wallet.source === "config") {
+    api.logger.info(`Using wallet from plugin config: ${wallet.address}`);
   } else {
     api.logger.info(`Using wallet from BLOCKRUN_WALLET_KEY: ${wallet.address}`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -539,10 +539,15 @@ async function startProxyInBackground(api: OpenClawPluginApi): Promise<void> {
   const configKey = api.pluginConfig?.walletKey as string | undefined;
   let wallet: WalletResolution;
 
-  if (typeof configKey === "string" && configKey.startsWith("0x") && configKey.length === 66) {
+  if (typeof configKey === "string" && /^0x[0-9a-fA-F]{64}$/.test(configKey)) {
     const account = privateKeyToAccount(configKey as `0x${string}`);
     wallet = { key: configKey, address: account.address, source: "config" };
   } else {
+    if (configKey !== undefined) {
+      api.logger.warn(
+        `pluginConfig.walletKey is set but invalid (expected 0x + 64 hex chars) — falling back to saved wallet`,
+      );
+    }
     wallet = await resolveOrGenerateWalletKey();
   }
 


### PR DESCRIPTION
## Bug

`openclaw.plugin.json` declares `walletKey` in its `configSchema`:

\`\`\`json
"walletKey": {
  "type": "string",
  "description": "EVM wallet private key (0x...). Optional — auto-generated if not set."
}
\`\`\`

The programmatic `startProxy({ walletKey })` API also accepts it. However, `startProxyInBackground()` never reads `api.pluginConfig?.walletKey` — it always calls `resolveOrGenerateWalletKey()` (saved file → env var → auto-generate), silently ignoring any value set in `openclaw.json`.

## Fix

Check `api.pluginConfig?.walletKey` before the file/env resolution chain. If present and valid, use it directly with source `"config"`. The existing resolution order is unchanged when `walletKey` is absent or invalid.

\`\`\`diff
-const wallet = await resolveOrGenerateWalletKey();
+const configKey = api.pluginConfig?.walletKey as string | undefined;
+let wallet: WalletResolution;
+if (typeof configKey === "string" && configKey.startsWith("0x") && configKey.length === 66) {
+  const account = privateKeyToAccount(configKey as \`0x\${string}\`);
+  wallet = { key: configKey, address: account.address, source: "config" };
+} else {
+  wallet = await resolveOrGenerateWalletKey();
+}
\`\`\`

## Testing

Added `walletKey` to the `plugins.entries.clawrouter.config` section of `openclaw.json`, restarted the gateway, and confirmed the log line:

\`\`\`
[gateway] Using wallet from plugin config: 0x97d9...
\`\`\`

Previously the gateway always logged `Using saved wallet: 0x<treasury-wallet>` regardless of any configured key.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin config can now supply a wallet private key; when valid, it is used ahead of saved wallets and environment variables.
  * Logging now indicates when a wallet from plugin config is in use, alongside existing source notices.

* **Bug Fixes**
  * If a configured wallet key is invalid, a warning is logged and the system falls back to the previous resolution order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->