### PR TITLE
skill: add tx402.ai — EU LLM inference via x402 micropayments

### DIFF
--- a/skills/tx402ai/SKILL.md
+++ b/skills/tx402ai/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: tx402ai
+description: Agent-native LLM inference via x402 micropayments. 20+ EU-hosted models (DeepSeek, Qwen, Llama, GLM, Mixtral) with USDC on Base. No API keys, no accounts — wallet is auth. OpenAI-compatible drop-in replacement. GDPR-compliant, zero data retention.
+homepage: https://tx402.ai
+metadata: { "openclaw": { "emoji": "⚡", "tags": ["llm", "inference", "x402", "eu", "gdpr"] } }
+---
+
+# tx402.ai — Agent-Native LLM Gateway
+
+x402 payment gateway for EU-sovereign LLM inference. AI agents pay per-request with USDC on Base. No API keys, no accounts, no KYC. Wallet = authentication.
+
+## Quick Start
+
+```typescript
+import { wrapFetchWithPayment } from "@x402/fetch";
+import { ExactEvmScheme } from "@x402/evm";
+
+const paidFetch = wrapFetchWithPayment(fetch, signer, [new ExactEvmScheme()]);
+
+const res = await paidFetch("https://tx402.ai/v1/chat/completions", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    model: "deepseek/deepseek-v3.2",
+    messages: [{ role: "user", content: "Hello from an autonomous agent" }],
+  }),
+});
+```
+
+## Available Models (20+)
+
+| Model | Type | Est. Cost/Request |
+|-------|------|-------------------|
+| DeepSeek V3.2 | Chat | ~$0.0003 |
+| DeepSeek R1 | Reasoning | ~$0.001 |
+| Qwen3-235B | Chat | ~$0.0003 |
+| Llama 4 Maverick | Chat | ~$0.0003 |
+| GLM-5 | Chat | ~$0.001 |
+| Mixtral | Chat | ~$0.0003 |
+| GPT-OSS-120B | Chat | ~$0.001 |
+
+Full model list with live pricing: https://tx402.ai/v1/models
+
+## Model Aliases
+
+Use short names for convenience: `deepseek`, `deepseek-r1`, `qwen`, `llama`, `llama-70b`, `glm`, `glm-5`, `minimax`, `kimi`, `mixtral`, `gpt-oss`
+
+## Features
+
+- **x402 protocol** — USDC micropayments on Base
+- **OpenAI-compatible** — same API format, drop-in replacement
+- **SSE streaming** — real-time token streaming
+- **Dynamic pricing** — live from Tensorix, auto-refreshed every 6h
+- **EU-sovereign** — GDPR-compliant, zero data retention
+- **Agent discovery** — llms.txt, ai-plugin.json, .well-known/x402, OpenAPI 3.1
+
+## Endpoints
+
+- `POST /v1/chat/completions` — chat (x402 payment required)
+- `POST /v1/completions` — text completions (x402 payment required)
+- `POST /v1/embeddings` — embeddings (x402 payment required)
+- `GET /v1/models` — model list with pricing (free)
+- `GET /openapi.json` — OpenAPI 3.1 spec (free)
+- `GET /llms.txt` — agent discovery file (free)
+
+## How Payment Works
+
+1. Agent sends request without `X-PAYMENT` header → gets 402 with pricing + nonce
+2. Agent signs USDC payment using `@x402/fetch`
+3. Agent retries with `X-PAYMENT` header → gets LLM response
+4. Total round-trip: ~2 seconds including payment verification
+
+## Links
+
+- Website: https://tx402.ai
+- Models: https://tx402.ai/v1/models
+- Health: https://tx402.ai/health
+- OpenAPI: https://tx402.ai/openapi.json
+- Protocol: https://x402.org


### PR DESCRIPTION
## Add tx402.ai Skill

Adds a skill for [tx402.ai](https://tx402.ai) — an x402 payment gateway for agent-native EU LLM inference.

### Why this is useful for ClawRouter users

tx402.ai provides an alternative x402-compatible LLM endpoint with:

- **20+ EU-hosted models** — DeepSeek V3/R1, Qwen3-235B, Llama 4 Maverick, GLM-5, Mixtral, GPT-OSS
- **Same x402 protocol** — works with `@x402/fetch`, same wallet, USDC on Base
- **OpenAI-compatible API** — drop-in at `/v1/chat/completions`
- **EU-sovereign** — GDPR-compliant, zero data retention, EU infrastructure
- **Dynamic pricing** — per-model, auto-refreshed from Tensorix every 6h
- **Agent discovery** — `llms.txt`, `ai-plugin.json`, `.well-known/x402`, OpenAPI 3.1

### Live & Verified

- First mainnet x402 payment: March 2026 ✅
- Health: https://tx402.ai/health
- Models: https://tx402.ai/v1/models
- OpenAPI: https://tx402.ai/openapi.json

### Files Added

- `skills/tx402ai/SKILL.md` — skill definition with quick start, model list, pricing, aliases, and endpoint reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for the `tx402.ai` Agent-Native LLM Gateway service, including TypeScript quick-start examples, available models with per-request cost estimates, supported endpoints for chat, completions, embeddings, and models, OpenAI-compatible API, streaming support, and USDC payment flow on Base without requiring API keys or accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->