### PR TITLE
fix: apply routing config on proxy reuse path (defense-in-depth)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -516,9 +516,6 @@ function injectModelsConfig(
   }
 }
 
-function readStringSafe(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
 
 /**
  * Inject dummy auth profile for BlockRun into agent auth stores.

--- a/src/proxy.routing-config-reuse.test.ts
+++ b/src/proxy.routing-config-reuse.test.ts
@@ -49,7 +49,9 @@ describe("startProxy routing config reuse", () => {
       expect(updatedConfig.tiers.SIMPLE.fallback).toEqual(["test-fallback-1"]);
 
       // Other tiers should still have defaults (merged, not replaced)
-      expect(updatedConfig.tiers.COMPLEX.primary).toBe(DEFAULT_ROUTING_CONFIG.tiers.COMPLEX.primary);
+      expect(updatedConfig.tiers.COMPLEX.primary).toBe(
+        DEFAULT_ROUTING_CONFIG.tiers.COMPLEX.primary,
+      );
     } finally {
       await firstProxy.close();
     }

--- a/src/proxy.routing-config-reuse.test.ts
+++ b/src/proxy.routing-config-reuse.test.ts
@@ -27,7 +27,7 @@ describe("startProxy routing config reuse", () => {
       const customConfig: Parameters<typeof startProxy>[0]["routingConfig"] = {
         tiers: {
           SIMPLE: { primary: "test-model-simple", fallback: ["test-fallback-1"] },
-        } as any,
+        } as Record<string, { primary: string; fallback: string[] }>,
       };
 
       // Start proxy again on same port — enters reuse path

--- a/src/proxy.routing-config-reuse.test.ts
+++ b/src/proxy.routing-config-reuse.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { generatePrivateKey } from "viem/accounts";
+
+import { startProxy } from "./proxy.js";
+import { DEFAULT_ROUTING_CONFIG } from "./router/index.js";
+
+describe("startProxy routing config reuse", () => {
+  it("applies custom routing config when reusing an existing proxy", async () => {
+    const walletKey = generatePrivateKey();
+    const port = 21000 + Math.floor(Math.random() * 10000);
+
+    // Start the first proxy (uses DEFAULT_ROUTING_CONFIG)
+    const firstProxy = await startProxy({
+      wallet: walletKey,
+      port,
+      skipBalanceCheck: true,
+    });
+
+    try {
+      // Verify initial config is the default
+      const initialRes = await fetch(`${firstProxy.baseUrl}/__routing-config`);
+      expect(initialRes.status).toBe(200);
+      const initialConfig = await initialRes.json();
+      expect(initialConfig.version).toBe(DEFAULT_ROUTING_CONFIG.version);
+
+      // Custom routing config with a modified tier
+      const customConfig: Parameters<typeof startProxy>[0]["routingConfig"] = {
+        tiers: {
+          SIMPLE: { primary: "test-model-simple", fallback: ["test-fallback-1"] },
+        } as any,
+      };
+
+      // Start proxy again on same port — enters reuse path
+      const secondProxy = await startProxy({
+        wallet: walletKey,
+        port,
+        skipBalanceCheck: true,
+        routingConfig: customConfig,
+      });
+
+      // The second proxy's close is a no-op (reuse path)
+      await secondProxy.close();
+
+      // Verify the routing config was updated on the running proxy
+      const updatedRes = await fetch(`${firstProxy.baseUrl}/__routing-config`);
+      expect(updatedRes.status).toBe(200);
+      const updatedConfig = await updatedRes.json();
+      expect(updatedConfig.tiers.SIMPLE.primary).toBe("test-model-simple");
+      expect(updatedConfig.tiers.SIMPLE.fallback).toEqual(["test-fallback-1"]);
+
+      // Other tiers should still have defaults (merged, not replaced)
+      expect(updatedConfig.tiers.COMPLEX.primary).toBe(DEFAULT_ROUTING_CONFIG.tiers.COMPLEX.primary);
+    } finally {
+      await firstProxy.close();
+    }
+  });
+
+  it("leaves default routing config when reusing without routingConfig option", async () => {
+    const walletKey = generatePrivateKey();
+    const port = 21000 + Math.floor(Math.random() * 10000);
+
+    const firstProxy = await startProxy({
+      wallet: walletKey,
+      port,
+      skipBalanceCheck: true,
+    });
+
+    try {
+      // Reuse without routingConfig
+      const secondProxy = await startProxy({
+        wallet: walletKey,
+        port,
+        skipBalanceCheck: true,
+      });
+      await secondProxy.close();
+
+      // Config should still be the default
+      const res = await fetch(`${firstProxy.baseUrl}/__routing-config`);
+      expect(res.status).toBe(200);
+      const config = await res.json();
+      expect(config.version).toBe(DEFAULT_ROUTING_CONFIG.version);
+      expect(config.tiers).toEqual(DEFAULT_ROUTING_CONFIG.tiers);
+    } finally {
+      await firstProxy.close();
+    }
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1806,9 +1806,12 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
           };
           if (body.routingConfig) {
             routerOpts.config = mergeRoutingConfig(body.routingConfig);
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ updated: true }));
+          } else {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ updated: false }));
           }
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ updated: true }));
         } catch (err) {
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1621,6 +1621,26 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
       balanceMonitor = new BalanceMonitor(account.address);
     }
 
+    // If a routing config was provided, push it to the running proxy so it takes effect
+    if (options.routingConfig) {
+      try {
+        const updateRes = await fetch(`${baseUrl}/__update-routing`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ routingConfig: options.routingConfig }),
+        });
+        if (!updateRes.ok) {
+          console.warn(
+            `[ClawRouter] Failed to update routing config on existing proxy: ${updateRes.status}`,
+          );
+        }
+      } catch (err) {
+        console.warn(
+          `[ClawRouter] Could not update routing config on existing proxy: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
     options.onReady?.(listenPort);
 
     return {
@@ -1771,6 +1791,39 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
 
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify(response));
+        return;
+      }
+
+      // Internal endpoint: update routing config on a running proxy (used by reuse path)
+      if (req.method === "POST" && req.url === "/__update-routing") {
+        try {
+          const chunks: Buffer[] = [];
+          for await (const chunk of req) {
+            chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+          }
+          const body = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as {
+            routingConfig?: Partial<RoutingConfig>;
+          };
+          if (body.routingConfig) {
+            routerOpts.config = mergeRoutingConfig(body.routingConfig);
+          }
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ updated: true }));
+        } catch (err) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error: `Invalid routing config: ${err instanceof Error ? err.message : String(err)}`,
+            }),
+          );
+        }
+        return;
+      }
+
+      // Internal endpoint: read current routing config (for testing/debugging)
+      if (req.method === "GET" && req.url === "/__routing-config") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(routerOpts.config));
         return;
       }
 


### PR DESCRIPTION
## Summary

Defense-in-depth fix for the `startProxy()` reuse path: when a second `register()` call hits an existing proxy via `checkExistingProxy()`, `routingConfig` was silently dropped because `mergeRoutingConfig` was never called on that path.

**Note:** This is a *different* bug than #147 (which was fixed in v0.12.142 via the single-process plugin path). This PR addresses the multi-process reuse scenario where `startProxy()` returns an existing proxy URL.

### What changed

1. New `/__update-routing` internal endpoint on the proxy server — accepts POST with routing config and calls `mergeRoutingConfig` on the running instance
2. `startProxy()` reuse path sends routing config to the running proxy when `routingConfig` is present
3. New `/__routing-config` debug endpoint for inspection
4. Returns `{ updated: false }` when no `routingConfig` provided (callers can distinguish no-op vs actual update)

### Limitation

Config applied this way is *additive* — it cannot remove overrides set by the first caller. This is inherent to the reuse model.

### Tests

- 2 new tests for the reuse-path scenario
- All 410 existing tests pass
- TypeCheck clean