### PR TITLE
docs: fix proxy port in free models guide

### DIFF
--- a/docs/11-free-ai-models-zero-cost-blockrun.md
+++ b/docs/11-free-ai-models-zero-cost-blockrun.md
@@ -164,7 +164,7 @@ clawrouter start
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="http://localhost:4402/v1",
+    base_url="http://localhost:8402/v1",
     api_key="your-blockrun-key"
 )
 
@@ -266,7 +266,7 @@ npm install -g @blockrun/clawrouter
 clawrouter start
 ```
 
-Point your `base_url` to `http://localhost:4402/v1`. That's the whole setup.
+Point your `base_url` to `http://localhost:8402/v1`. That's the whole setup.
 
 Eleven free models. 128K context. Unlimited calls. Zero cost.
 


### PR DESCRIPTION
## Summary
- Correct the free models guide to use ClawRouter's default proxy port, `8402`, in the Python example and quick-start text.

## Why
The rest of the repo, package config, and tests document `8402` as the default. The guide's `4402` examples would point users at the wrong local proxy.

## Test Plan
- `git diff --check`
- `git grep -n 4402 -- docs README.md src test package.json` (no matches)
- `npm test`
- `npm run typecheck`

Note: `npx prettier --check docs/11-free-ai-models-zero-cost-blockrun.md` also fails on the committed HEAD version of this article, so I left formatting untouched to avoid unrelated churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local proxy endpoint configuration examples for BlockRun/ClawRouter setup to reflect current port settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->