### PR TITLE
fix(manifest): declare contracts, providers, and onStartup so the plugin loads at gateway boot

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3,6 +3,42 @@
   "name": "ClawRouter",
   "description": "Smart LLM router — 55+ models, x402 micropayments, 92% cost savings. Phone lookup + AI voice calls (Twilio + Bland.ai). Surf crypto-data API (84 endpoints, on-chain SQL, 100M+ labeled wallets) via skill.",
   "skills": ["./skills"],
+  "activation": {
+    "onStartup": true
+  },
+  "enabledByDefault": true,
+  "providers": ["blockrun"],
+  "contracts": {
+    "tools": [
+      "blockrun_predexon_events",
+      "blockrun_predexon_leaderboard",
+      "blockrun_predexon_markets",
+      "blockrun_predexon_smart_money",
+      "blockrun_predexon_smart_activity",
+      "blockrun_predexon_wallet",
+      "blockrun_predexon_wallet_pnl",
+      "blockrun_predexon_matching_markets",
+      "blockrun_predexon_endpoint_call",
+      "blockrun_stock_price",
+      "blockrun_stock_history",
+      "blockrun_stock_list",
+      "blockrun_crypto_price",
+      "blockrun_fx_price",
+      "blockrun_commodity_price",
+      "blockrun_image_generation",
+      "blockrun_image_edit",
+      "blockrun_video_generation",
+      "blockrun_phone_lookup",
+      "blockrun_phone_lookup_fraud",
+      "blockrun_phone_numbers_buy",
+      "blockrun_phone_numbers_renew",
+      "blockrun_phone_numbers_list",
+      "blockrun_phone_numbers_release",
+      "blockrun_voice_call",
+      "blockrun_voice_status"
+    ],
+    "webSearchProviders": ["blockrun-exa"]
+  },
   "configSchema": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
## Summary

The `openclaw.plugin.json` manifest is missing the capability declarations that OpenClaw 2026.5.x's gateway-boot plugin loader requires. Without them the plugin is skipped at boot — `/wallet`, `/stats`, `/blockrun`, the BlockRun provider, and the x402 proxy on :8402 silently never come up after a gateway restart.

This PR adds the four manifest fields that fix it.

## Repro (before this PR)

OpenClaw 2026.5.19 (also reproduces on 2026.5.22) + ClawRouter 0.12.196, fresh install per the official one-liner:

```
curl -fsSL https://blockrun.ai/ClawRouter-update | bash
```

Then run `openclaw gateway restart`. Symptoms:

- `openclaw plugins inspect clawrouter` reports `Status: loaded` (the CLI tools are lenient and still load the plugin, which masks the issue)
- `openclaw plugins doctor` repeats the warning 26 times:
  ```
  - clawrouter: plugin must declare contracts.tools before registering agent tools
  ```
- After `openclaw gateway restart`:
  - port 8402 is **not** listening
  - the `BlockRun provider registered (55+ models via x402)` log line is absent
  - no `Commands registered: /wallet, /blockrun, /stats, ...` line
  - `http server listening (12 plugins: ...)` — `clawrouter` not in the list
  - inside the TUI, `/wallet` returns "no `/wallet` command exists"

What's happening: at install time the plugin loads via a hot-reload path that's lenient; once you restart the gateway the strict boot loader runs the contract check and skips the plugin because the manifest doesn't declare what it provides.

## Fix

Add the four declarations the gateway boot loader needs in `openclaw.plugin.json`:

- `activation.onStartup: true` — the plugin must run at boot to serve the x402 proxy on :8402; without it the plugin lazy-loads and the proxy never comes up
- `enabledByDefault: true` — opt into the trusted-by-default load path (matches `acpx`, `document-extract`, and other in-tree plugins)
- `providers: ["blockrun"]` — declare the LLM provider so the gateway knows this plugin owns the `blockrun/*` model IDs (same pattern as `anthropic`, `openai`)
- `contracts.tools: [...26 tools...]` — list the partner tools registered at runtime (`blockrun_predexon_*`, `blockrun_stock_*`, `blockrun_crypto_*`, `blockrun_phone_*`, `blockrun_voice_*`, `blockrun_image_*`, `blockrun_video_*`). This is what makes the 26x doctor warning go away
- `contracts.webSearchProviders: ["blockrun-exa"]` — declare the Exa-backed web search provider

The tools list was derived from the plugin's own runtime registration log (`[plugins] Registered 26 partner tool(s): ...`), so the manifest now matches what the code actually registers.

## Verification

On the same host, after applying this patch and running `openclaw gateway restart`, the gateway log shows:

```
[plugins] BlockRun provider registered (55+ models via x402)
[plugins] Registered BlockRun web_search provider (blockrun-exa)
[plugins] Registered 26 partner tool(s): blockrun_predexon_events, ...
[plugins] Commands registered: /wallet, /blockrun, /stats, /exclude, /partners, /cr-imagegen, /videogen, /cr-call
[gateway] http server listening (13 plugins: acpx, browser, canvas, clawrouter, ...)
[ClawRouter] ✓ Loaded existing wallet from /home/.../.openclaw/blockrun/wallet.key
[plugins] BlockRun x402 proxy listening on port 8402
[plugins] ClawRouter ready — smart routing enabled
```

And inside the OpenClaw TUI, `/wallet` returns the wallet status (address, balance, fund URLs) as expected.

`openclaw plugins inspect clawrouter` after the patch also shows the new shape:

```
Shape: plain-capability
Capability mode: plain
Capabilities:
  web-search: blockrun-exa
```

(Was `Shape: non-capability` / `Capability mode: none` before.)

## Test plan

- [ ] On a host with OpenClaw 2026.5.19+ and a fresh ClawRouter install, apply this patch and run `openclaw gateway restart`
- [ ] Confirm `openclaw plugins doctor` no longer prints the `plugin must declare contracts.tools` warning
- [ ] Confirm `ss -tlnp | grep 8402` shows a listener
- [ ] In the OpenClaw TUI, run `/wallet` and confirm the wallet panel renders
- [ ] If the plugin grows or removes tools later, keep `contracts.tools` in sync with the runtime registration in `dist/index.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin automatically activates on startup and is enabled by default
  * Expanded tool capabilities including financial data access (stocks, crypto, forex, commodities)
  * Additional media and communication tools now available
  * Integrated web search functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlockRunAI/ClawRouter/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->