### PR TITLE
Hide delisted/redirect aliases from the model list

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -1127,8 +1127,17 @@ function toOpenClawModel(m: BlockRunModel): ModelDefinitionConfig {
 /**
  * Alias models that map to real models.
  * These allow users to use friendly names like "free" or "gpt-120b".
+ *
+ * Only friendly short names are advertised. Full `provider/model` keys in
+ * MODEL_ALIASES are backward-compat / delisted redirects whose target is a real
+ * model that is already listed — surfacing them as their own entries is wrong
+ * (e.g. `free/deepseek-v4-pro` was delisted 2026-04-30 and redirects to
+ * `free/deepseek-v4-flash`, yet showed up as a listable "V4 Pro" model). They
+ * stay fully callable via resolveModelAlias(); they just must not appear in
+ * `/v1/models` or any picker.
  */
 const ALIAS_MODELS: ModelDefinitionConfig[] = Object.entries(MODEL_ALIASES)
+  .filter(([alias]) => !alias.includes("/"))
   .map(([alias, targetId]) => {
     const target = BLOCKRUN_MODELS.find((m) => m.id === targetId);
     if (!target) return null;


### PR DESCRIPTION
## Problem

`MODEL_ALIASES` mixes two kinds of entries:
- **friendly short names** — `free`, `opus`, `gpt-120b`
- **full `provider/model` redirects** — backward-compat + delisted models, e.g. `free/deepseek-v4-pro` → `free/deepseek-v4-flash` (V4 Pro delisted 2026-04-30 when the NVIDIA host hung).

`ALIAS_MODELS` turns **every** alias into a listable model, so dead slugs leak into `/v1/models` (and any downstream picker) as if they were real, available models. A Codex model picker built from `/v1/models` showed **"DeepSeek V4 Pro (free)"** that silently routes to v4-flash — misleading twice over (not Pro, not really there).

## Fix

Only surface friendly short aliases (no `/`). Full-slug redirect aliases are skipped from the advertised list — their target is a real model that's already listed, so nothing disappears. They remain **fully callable** via `resolveModelAlias()` (which reads `MODEL_ALIASES` directly), so pinned callers don't break. One-line filter in `ALIAS_MODELS`; `MODEL_ALIASES` and resolution are untouched.

## Verification

- `free/deepseek-v4-pro`, `nvidia/deepseek-v4-pro`, `xai/grok-code-fast-1`, `free/mistral-large-3-675b` → **gone** from the listed models
- `free/deepseek-v4-flash` (the real target) → still listed
- `resolveModelAlias('free/deepseek-v4-pro')` → still `free/deepseek-v4-flash` (callable)
- `npm run typecheck` ✓ · `npm run build` ✓ · model tests 7/7 ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for model naming and availability to clarify which model identifiers are publicly advertised versus those reserved for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->