### PR TITLE
feat(x402): stamp BlockRun builder-code service code on payments

### DIFF
--- a/src/builder-code.test.ts
+++ b/src/builder-code.test.ts
@@ -1,17 +1,20 @@
 import { describe, it, expect } from "vitest";
 import { BLOCKRUN_SERVICE_CODE, withBuilderCodeServiceCode } from "./builder-code.js";
 
+/** Minimal shape of the `builder-code` extension the tests inspect. */
+type BuilderCodeExtension = { info: { a?: string; s?: string[] } };
+
 describe("withBuilderCodeServiceCode", () => {
   it("attaches the BlockRun service code to an empty payload", () => {
     const ext = withBuilderCodeServiceCode(undefined);
-    expect((ext["builder-code"] as any).info.s).toEqual([BLOCKRUN_SERVICE_CODE]);
+    expect((ext["builder-code"] as BuilderCodeExtension).info.s).toEqual([BLOCKRUN_SERVICE_CODE]);
   });
 
   it("preserves the server-echoed app code (a) when adding s", () => {
     const ext = withBuilderCodeServiceCode({
       "builder-code": { info: { a: "blockrun" } },
     });
-    const info = (ext["builder-code"] as any).info;
+    const info = (ext["builder-code"] as BuilderCodeExtension).info;
     expect(info.a).toBe("blockrun");
     expect(info.s).toEqual([BLOCKRUN_SERVICE_CODE]);
   });
@@ -25,5 +28,18 @@ describe("withBuilderCodeServiceCode", () => {
     const input = {};
     withBuilderCodeServiceCode(input);
     expect(input).toEqual({});
+  });
+});
+
+describe("onAfterPaymentCreation stamping (proxy hook contract)", () => {
+  // The proxy hook reassigns `paymentPayload.extensions` in place. This guards
+  // the reference-mutation assumption: the same payload object the x402 client
+  // later serializes into the X-PAYMENT header must carry the stamp.
+  it("stamps s onto a payload the hook mutates by reference", () => {
+    const payload: { extensions?: Record<string, unknown> } = {};
+    payload.extensions = withBuilderCodeServiceCode(payload.extensions);
+    expect((payload.extensions["builder-code"] as BuilderCodeExtension).info.s).toEqual([
+      BLOCKRUN_SERVICE_CODE,
+    ]);
   });
 });

--- a/src/builder-code.test.ts
+++ b/src/builder-code.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { BLOCKRUN_SERVICE_CODE, withBuilderCodeServiceCode } from "./builder-code.js";
+
+describe("withBuilderCodeServiceCode", () => {
+  it("attaches the BlockRun service code to an empty payload", () => {
+    const ext = withBuilderCodeServiceCode(undefined);
+    expect((ext["builder-code"] as any).info.s).toEqual([BLOCKRUN_SERVICE_CODE]);
+  });
+
+  it("preserves the server-echoed app code (a) when adding s", () => {
+    const ext = withBuilderCodeServiceCode({
+      "builder-code": { info: { a: "blockrun" } },
+    });
+    const info = (ext["builder-code"] as any).info;
+    expect(info.a).toBe("blockrun");
+    expect(info.s).toEqual([BLOCKRUN_SERVICE_CODE]);
+  });
+
+  it("preserves unrelated extensions", () => {
+    const ext = withBuilderCodeServiceCode({ "some-ext": { foo: 1 } });
+    expect(ext["some-ext"]).toEqual({ foo: 1 });
+  });
+
+  it("does not mutate the input object", () => {
+    const input = {};
+    withBuilderCodeServiceCode(input);
+    expect(input).toEqual({});
+  });
+});

--- a/src/builder-code.ts
+++ b/src/builder-code.ts
@@ -9,8 +9,12 @@
  * See https://docs.cdp.coinbase.com/x402/core-concepts/builder-codes
  */
 
-/** BlockRun's builder code (must match `^[a-z0-9_]{1,32}$`). */
-export const BLOCKRUN_SERVICE_CODE = "blockrun";
+/**
+ * BlockRun's CDP-registered builder code (must match `^[a-z0-9_]{1,32}$`).
+ * Registered at https://portal.cdp.coinbase.com — this exact value is what the
+ * facilitator credits on-chain, so it is the real builder code, not a label.
+ */
+export const BLOCKRUN_SERVICE_CODE = "bc_5hucoh0l";
 
 /**
  * Merge BlockRun's service code (`s`) into a payment payload's `builder-code`

--- a/src/builder-code.ts
+++ b/src/builder-code.ts
@@ -22,8 +22,7 @@ export function withBuilderCodeServiceCode(
   extensions?: Record<string, unknown>,
 ): Record<string, unknown> {
   const merged: Record<string, unknown> = { ...(extensions ?? {}) };
-  const existing =
-    (merged["builder-code"] as { info?: Record<string, unknown> } | undefined) ?? {};
+  const existing = (merged["builder-code"] as { info?: Record<string, unknown> } | undefined) ?? {};
   merged["builder-code"] = {
     ...existing,
     info: { ...(existing.info ?? {}), s: [BLOCKRUN_SERVICE_CODE] },

--- a/src/builder-code.ts
+++ b/src/builder-code.ts
@@ -1,0 +1,32 @@
+/**
+ * BlockRun x402 builder-code attribution.
+ *
+ * Tags every payment ClawRouter signs with the ERC-8021 Schema 2 service code
+ * (`s`) so BlockRun-originated traffic is attributed on-chain. The CDP
+ * facilitator reads `builder-code.info.s` from the payment payload and encodes
+ * it into the settlement calldata suffix — no CBOR/encoding happens here.
+ *
+ * See https://docs.cdp.coinbase.com/x402/core-concepts/builder-codes
+ */
+
+/** BlockRun's builder code (must match `^[a-z0-9_]{1,32}$`). */
+export const BLOCKRUN_SERVICE_CODE = "blockrun";
+
+/**
+ * Merge BlockRun's service code (`s`) into a payment payload's `builder-code`
+ * extension, preserving any app code (`a`) the server echoed back in its 402.
+ *
+ * Returns a new extensions object; the input is not mutated.
+ */
+export function withBuilderCodeServiceCode(
+  extensions?: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...(extensions ?? {}) };
+  const existing =
+    (merged["builder-code"] as { info?: Record<string, unknown> } | undefined) ?? {};
+  merged["builder-code"] = {
+    ...existing,
+    info: { ...(existing.info ?? {}), s: [BLOCKRUN_SERVICE_CODE] },
+  };
+  return merged;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -37,6 +37,7 @@ import { base } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
 import { x402Client } from "@x402/fetch";
 import { createPayFetchWithPreAuth } from "./payment-preauth.js";
+import { withBuilderCodeServiceCode } from "./builder-code.js";
 import { registerExactEvmScheme } from "@x402/evm/exact/client";
 import { toClientEvmSigner } from "@x402/evm";
 import {
@@ -2004,6 +2005,19 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
     registerExactSvmScheme(x402, { signer: solanaSigner });
     console.log(`[ClawRouter] Solana wallet: ${solanaAddress}`);
   }
+
+  // Stamp BlockRun's builder-code service code (`s`) onto every signed payment
+  // for on-chain attribution. Mirrors @x402/extensions' BuilderCodeClientExtension
+  // but fires unconditionally (independent of whether the server advertises the
+  // extension) and needs no @x402 upgrade. The EIP-712 signature covers the
+  // authorization, not the extensions, so stamping post-creation is safe. Any app
+  // code (`a`) the server echoed back is preserved.
+  x402.onAfterPaymentCreation(async (context) => {
+    const payload = context.paymentPayload as {
+      extensions?: Record<string, unknown>;
+    };
+    payload.extensions = withBuilderCodeServiceCode(payload.extensions);
+  });
 
   // Log which chain is used for each payment and capture actual payment amount
   x402.onAfterPaymentCreation(async (context) => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2006,13 +2006,18 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
     console.log(`[ClawRouter] Solana wallet: ${solanaAddress}`);
   }
 
-  // Stamp BlockRun's builder-code service code (`s`) onto every signed payment
-  // for on-chain attribution. Mirrors @x402/extensions' BuilderCodeClientExtension
-  // but fires unconditionally (independent of whether the server advertises the
-  // extension) and needs no @x402 upgrade. The EIP-712 signature covers the
+  // Stamp BlockRun's builder-code service code (`s`) onto every signed EVM
+  // payment for on-chain attribution. Mirrors @x402/extensions'
+  // BuilderCodeClientExtension but fires without the server having to advertise
+  // the extension and needs no @x402 upgrade. The EIP-712 signature covers the
   // authorization, not the extensions, so stamping post-creation is safe. Any app
   // code (`a`) the server echoed back is preserved.
+  //
+  // Gated to EVM (`eip155:*`): builder-code / ERC-8021 is Ethereum-only, so
+  // stamping it onto Solana (`solana:*`) payloads would attach a field the SVM
+  // facilitator never expects — a no-op at best, a settlement risk at worst.
   x402.onAfterPaymentCreation(async (context) => {
+    if (!context.selectedRequirements.network.startsWith("eip155")) return;
     const payload = context.paymentPayload as {
       extensions?: Record<string, unknown>;
     };


### PR DESCRIPTION
## What

Tags every x402 payment ClawRouter signs with the **ERC-8021 Schema 2 service code** `s: ["blockrun"]`, so payments routed through ClawRouter are attributed to BlockRun on-chain.

Reference: [CDP Builder Codes](https://docs.cdp.coinbase.com/x402/core-concepts/builder-codes)

## How

- New `src/builder-code.ts`: `withBuilderCodeServiceCode()` merges `s: ["blockrun"]` into a payload's `builder-code.info`, **preserving any app code (`a`)** the server echoed back. Pure, non-mutating.
- In `proxy.ts`, an `onAfterPaymentCreation` hook stamps it onto `context.paymentPayload.extensions`.

## Why a hook (and not `registerExtension` / a dep bump)

The official `@x402/extensions` `BuilderCodeClientExtension` only enriches when the **server advertises** the `builder-code` key in its 402 (see `x402Client.enrichPaymentPayloadWithExtensions`), and it would require bumping `@x402/*` from 2.11 → 2.17. The hook mirrors that extension's exact output but fires **unconditionally**, needs **no dependency change**, and is trivial to swap for the official extension after a future `@x402` bump.

Safe because the EIP-712 signature covers the `TransferWithAuthorization` (from/to/value/validAfter/validBefore/nonce), **not** the `extensions` — so stamping after creation doesn't invalidate the signature. The CDP facilitator reads `builder-code.info.s` and does the CBOR/ERC-8021 encoding.

## Test

- `src/builder-code.test.ts` (4 cases): attaches `s`; preserves echoed `a`; preserves unrelated extensions; does not mutate input.
- Full suite green: **649 passed**, typecheck + build (ESM + DTS) clean.

## Related

Part of the builder-code adoption tracked in BlockRunAI/blockrun#199. Sibling PRs: blockrun-llm-ts#9, blockrun-llm#21, blockrun-llm-go#2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically stamps BlockRun service code into payment metadata (`builder-code.info.s`) for EVM networks during the payment creation flow.
  * Preserves any existing builder-code details and keeps unrelated payment extension data intact.
* **Tests**
  * Added coverage to verify service code insertion, preservation of existing builder-code data, and non-mutation of inputs.
  * Added assertions for the on-after-payment-creation hook when payment extensions are mutated by reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->