### PR TITLE
fix: preserve ERC-8021 service attribution

### DIFF
--- a/src/builder-code.test.ts
+++ b/src/builder-code.test.ts
@@ -32,6 +32,17 @@ describe("withBuilderCodeServiceCode", () => {
     expect(serviceCodes).toEqual(["bc_existing"]);
   });
 
+  it("preserves valid service codes from a partially malformed array", () => {
+    const ext = withBuilderCodeServiceCode({
+      "builder-code": { info: { s: ["bc_existing", 42, null] } },
+    });
+
+    expect((ext["builder-code"] as BuilderCodeExtension).info.s).toEqual([
+      "bc_existing",
+      BLOCKRUN_SERVICE_CODE,
+    ]);
+  });
+
   it("does not duplicate an existing BlockRun service code", () => {
     const ext = withBuilderCodeServiceCode({
       "builder-code": { info: { s: ["bc_existing", BLOCKRUN_SERVICE_CODE] } },

--- a/src/builder-code.test.ts
+++ b/src/builder-code.test.ts
@@ -19,6 +19,30 @@ describe("withBuilderCodeServiceCode", () => {
     expect(info.s).toEqual([BLOCKRUN_SERVICE_CODE]);
   });
 
+  it("appends the BlockRun code after existing service attribution", () => {
+    const serviceCodes = ["bc_existing"];
+    const ext = withBuilderCodeServiceCode({
+      "builder-code": { info: { a: "app", s: serviceCodes } },
+    });
+    const info = (ext["builder-code"] as BuilderCodeExtension).info;
+
+    expect(info.a).toBe("app");
+    expect(info.s).toEqual(["bc_existing", BLOCKRUN_SERVICE_CODE]);
+    expect(info.s).not.toBe(serviceCodes);
+    expect(serviceCodes).toEqual(["bc_existing"]);
+  });
+
+  it("does not duplicate an existing BlockRun service code", () => {
+    const ext = withBuilderCodeServiceCode({
+      "builder-code": { info: { s: ["bc_existing", BLOCKRUN_SERVICE_CODE] } },
+    });
+
+    expect((ext["builder-code"] as BuilderCodeExtension).info.s).toEqual([
+      "bc_existing",
+      BLOCKRUN_SERVICE_CODE,
+    ]);
+  });
+
   it("preserves unrelated extensions", () => {
     const ext = withBuilderCodeServiceCode({ "some-ext": { foo: 1 } });
     expect(ext["some-ext"]).toEqual({ foo: 1 });

--- a/src/builder-code.ts
+++ b/src/builder-code.ts
@@ -27,9 +27,18 @@ export function withBuilderCodeServiceCode(
 ): Record<string, unknown> {
   const merged: Record<string, unknown> = { ...(extensions ?? {}) };
   const existing = (merged["builder-code"] as { info?: Record<string, unknown> } | undefined) ?? {};
+  const existingServiceCodes =
+    Array.isArray(existing.info?.s) && existing.info.s.every((code) => typeof code === "string")
+      ? existing.info.s
+      : [];
   merged["builder-code"] = {
     ...existing,
-    info: { ...(existing.info ?? {}), s: [BLOCKRUN_SERVICE_CODE] },
+    info: {
+      ...(existing.info ?? {}),
+      s: existingServiceCodes.includes(BLOCKRUN_SERVICE_CODE)
+        ? [...existingServiceCodes]
+        : [...existingServiceCodes, BLOCKRUN_SERVICE_CODE],
+    },
   };
   return merged;
 }

--- a/src/builder-code.ts
+++ b/src/builder-code.ts
@@ -27,10 +27,9 @@ export function withBuilderCodeServiceCode(
 ): Record<string, unknown> {
   const merged: Record<string, unknown> = { ...(extensions ?? {}) };
   const existing = (merged["builder-code"] as { info?: Record<string, unknown> } | undefined) ?? {};
-  const existingServiceCodes =
-    Array.isArray(existing.info?.s) && existing.info.s.every((code) => typeof code === "string")
-      ? existing.info.s
-      : [];
+  const existingServiceCodes = Array.isArray(existing.info?.s)
+    ? existing.info.s.filter((code): code is string => typeof code === "string")
+    : [];
   merged["builder-code"] = {
     ...existing,
     info: {


### PR DESCRIPTION
## Summary

- preserve valid pre-existing `builder-code.info.s` service codes
- append BlockRun's registered code only when absent
- return a fresh service-code array without mutating the payment challenge

Fixes #199.

## Proof

- focused builder-code tests: 7 passed
- full suite: 652 passed, 3 skipped
- Node 22.22.2/npm 10.9.7: typecheck, lint, Prettier, and build pass
- source-blind behavior contract: existing attribution retained; already-stamped payload deduplicated; prior overwrite implementation rejected

No changelog edit: contributor PR; maintainer release notes own the entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves any existing `builder-code.info.s` service code entries when updating builder code.
  * Avoids adding duplicate BlockRun service codes.
  * Filters out invalid/non-string entries while ensuring the required service code is present.

* **Tests**
  * Added Vitest cases covering preservation, invalid-entry handling, and idempotency for builder code updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->