### PR TITLE
feat: add JMT x402 Agent Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,3 +734,5 @@ ClawRouter itself is free and MIT licensed. You pay only for the LLM API calls r
 ⭐ If ClawRouter powers your agents, consider starring the repo!
 
 </div>
+
+- [JMT x402 Agent Tools](https://jmt-x402-proxy.jmthomasofficial.workers.dev) — 25 paid x402 endpoints on Base mainnet: web search, AI analysis, crypto/stock data, SEC filings, company intel, news, sentiment, macro dashboard. $0.001-$0.15/call USDC. Local LLM-powered.


### PR DESCRIPTION
## What\n\nAdds JMT x402 Agent Tools — 25 paid x402 endpoints on Base mainnet.\n\n## Service Details\n\n- **URL:** https://jmt-x402-proxy.jmthomasofficial.workers.dev\n- **Network:** Base mainnet (eip155:8453)\n- **Endpoints:** 25 paid endpoints covering web search, AI analysis, crypto/stock data, SEC filings, company intel, news, sentiment, macro dashboard\n- **Price range:** $0.001-$0.15 per call\n- **Currency:** USDC on Base\n- **Wallet:** 0x624FaF18C78456C8Da5bf156Cd77c1A2033F21c5\n- **Discovery:** /.well-known/x402, /openapi.json, /llms.txt\n\n## Verification\n\n- [x] curl -I https://jmt-x402-proxy.jmthomasofficial.workers.dev/api/search returns 402\n- [x] /.well-known/x402 returns valid x402 discovery document\n- [x] /openapi.json has x-payment-info on all paid operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a footer resource for “JMT x402 Agent Tools.”
  * Included a link to the external service and an overview of its available paid endpoints.
  * Documented supported capabilities, including web search, AI analysis, market data, SEC filings, company intelligence, news, sentiment, and macroeconomic information.
  * Added pricing details of $0.001–$0.15 per call and noted local LLM-powered routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->