### PR TITLE
fix: preserve OpenClaw plugin allowlist on update

### DIFF
--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -214,7 +214,7 @@ for (const key of ['clawrouter', 'ClawRouter', '@blockrun/clawrouter']) {
 // plugin the user has allowed, including bare local/custom plugin IDs.
 if (Array.isArray(c.plugins?.allow)) {
   const before = c.plugins.allow.length;
-  c.plugins.allow = c.plugins.allow.filter(p => p !== 'clawrouter' && p !== '@blockrun/clawrouter');
+  c.plugins.allow = c.plugins.allow.filter(p => p !== 'clawrouter' && p !== 'ClawRouter' && p !== '@blockrun/clawrouter');
   const removed = before - c.plugins.allow.length;
   if (removed > 0) console.log('  Removed ClawRouter from plugins.allow (re-added after install)');
 }

--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -210,28 +210,13 @@ for (const key of ['clawrouter', 'ClawRouter', '@blockrun/clawrouter']) {
   if (c.plugins?.installs?.[key]) delete c.plugins.installs[key];
 }
 
-// Clean plugins.allow — remove clawrouter (will be re-added after install)
-// and strip any non-bundled plugin names that don't exist (e.g. "wallet" added
-// by an AI agent trying to fix a different problem — causes a warning on every start).
+// Clean plugins.allow — remove only ClawRouter entries; preserve every other
+// plugin the user has allowed, including bare local/custom plugin IDs.
 if (Array.isArray(c.plugins?.allow)) {
-  const BUNDLED_OPENCLAW_PLUGINS = [
-    // OpenClaw v2026.x bundled plugin IDs (safe to keep in allow list)
-    'http', 'mcp', 'computer-use', 'browser', 'code', 'image', 'voice',
-    'search', 'memory', 'calendar', 'email', 'slack', 'discord', 'telegram',
-    'whatsapp', 'matrix', 'teams', 'notion', 'github', 'jira', 'linear',
-    'comfyui',
-  ];
   const before = c.plugins.allow.length;
-  c.plugins.allow = c.plugins.allow.filter(p => {
-    if (p === 'clawrouter' || p === '@blockrun/clawrouter') return false; // re-added later
-    if (BUNDLED_OPENCLAW_PLUGINS.includes(p)) return true; // known-good bundled plugins
-    // Keep entries that look like npm package names (scoped or plain)
-    if (p.startsWith('@') || p.includes('/')) return true;
-    // Drop bare single-word entries that aren't bundled (e.g. "wallet" added by mistake)
-    return false;
-  });
+  c.plugins.allow = c.plugins.allow.filter(p => p !== 'clawrouter' && p !== '@blockrun/clawrouter');
   const removed = before - c.plugins.allow.length;
-  if (removed > 0) console.log('  Removed ' + removed + ' stale plugins.allow entry(ies)');
+  if (removed > 0) console.log('  Removed ClawRouter from plugins.allow (re-added after install)');
 }
 
 // OpenClaw 2026.5.2+ validates tools.web.search.provider at config-load time.

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -223,25 +223,13 @@ try {
     if (installs?.[key]) { delete installs[key]; changed = true; console.log('  Removed plugins.installs.' + key); }
   }
 
-  // Clean plugins.allow — remove clawrouter (re-added later) and any stale bare
-  // single-word entries that aren't bundled OpenClaw plugins (e.g. "wallet" added
-  // by an AI agent — shows a warning on every gateway start).
+  // Clean plugins.allow — remove only ClawRouter entries; preserve every other
+  // plugin the user has allowed, including bare local/custom plugin IDs.
   if (Array.isArray(config?.plugins?.allow)) {
-    const BUNDLED = [
-      'http','mcp','computer-use','browser','code','image','voice',
-      'search','memory','calendar','email','slack','discord','telegram',
-      'whatsapp','matrix','teams','notion','github','jira','linear',
-      'comfyui',
-    ];
     const before = config.plugins.allow.length;
-    config.plugins.allow = config.plugins.allow.filter(p => {
-      if (p === 'clawrouter' || p === '@blockrun/clawrouter') return false;
-      if (BUNDLED.includes(p)) return true;
-      if (p.startsWith('@') || p.includes('/')) return true;
-      return false;
-    });
+    config.plugins.allow = config.plugins.allow.filter(p => p !== 'clawrouter' && p !== '@blockrun/clawrouter');
     const removed = before - config.plugins.allow.length;
-    if (removed > 0) { changed = true; console.log('  Removed ' + removed + ' stale plugins.allow entry(ies)'); }
+    if (removed > 0) { changed = true; console.log('  Removed ClawRouter from plugins.allow (re-added after install)'); }
   }
 
   // OpenClaw 2026.5.2+ validates tools.web.search.provider at config-load

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -227,7 +227,7 @@ try {
   // plugin the user has allowed, including bare local/custom plugin IDs.
   if (Array.isArray(config?.plugins?.allow)) {
     const before = config.plugins.allow.length;
-    config.plugins.allow = config.plugins.allow.filter(p => p !== 'clawrouter' && p !== '@blockrun/clawrouter');
+    config.plugins.allow = config.plugins.allow.filter(p => p !== 'clawrouter' && p !== 'ClawRouter' && p !== '@blockrun/clawrouter');
     const removed = before - config.plugins.allow.length;
     if (removed > 0) { changed = true; console.log('  Removed ClawRouter from plugins.allow (re-added after install)'); }
   }


### PR DESCRIPTION
## Summary
- preserve existing OpenClaw plugins when running the ClawRouter update/reinstall scripts
- remove only ClawRouter entries from plugins.allow before re-adding ClawRouter after install
- keep intentional lobster/crossmint conflict cleanup unchanged

## Tests
- bash -n scripts/update.sh && bash -n scripts/reinstall.sh
- simulated plugins.allow cleanup preserves bare custom plugin IDs and npm-style plugin IDs
- npm run format:check
- npm run typecheck
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the reinstall and update processes so configuration cleanup removes only ClawRouter-related entries from the plugin allowlist.
  * Kept all other user-approved plugin entries unchanged during cleanup.
  * Adjusted the cleanup messaging to accurately describe what was removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->