### PR TITLE
perf(build): stop publishing sourcemaps (50.0MB → 16.6MB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to ClawRouter.
 
 ---
 
+## v0.12.224 — July 14, 2026
+
+**Two thirds of what we published was sourcemaps.** No behaviour change.
+
+### Changed — stop shipping sourcemaps to npm
+
+- The tarball carried `dist/index.js.map` and `dist/cli.js.map` at ~17MB each: **34MB of a 50MB install, 68% of the package**, downloaded by everyone who has ever run `npx @blockrun/clawrouter` or installed anything that depends on us. Excluded via `"!dist/**/*.map"` in package.json `files`. **50.0MB → 16.6MB unpacked** (3.4MB packed).
+- `sourcemap: true` stays in `tsup.config.ts` — maps are still generated for local debugging and CI, they just no longer ship. The bundles keep their `//# sourceMappingURL=` comment; a missing map is silently ignored at runtime. Verified the published tarball runs both normally and under `node --enable-source-maps`.
+- Context: this only became visible while auditing why `@blockrun/mcp` was paying ~50MB (≈15% of its install tree) for a router it never called. See `@blockrun/llm@3.6.0`, which stops installing us for consumers that don't route.
+
+---
+
 ## v0.12.223 — July 14, 2026
 
 **Hotfix again: v0.12.222 could not be installed as an OpenClaw plugin.** Plus a repair for the model list that kept showing retired models.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/clawrouter",
-  "version": "0.12.223",
+  "version": "0.12.224",
   "description": "Smart LLM router — save 85% on inference costs. 55+ models (8 free), one wallet, x402 micropayments.",
   "type": "module",
   "main": "dist/index.js",
@@ -25,6 +25,7 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.map",
     "docs/*.md",
     "docs/*.png",
     "scripts",


### PR DESCRIPTION
## Why

Two thirds of what we publish is sourcemaps.

| | size |
|---|---|
| `dist/index.js.map` | ~17MB |
| `dist/cli.js.map` | ~17MB |
| **sourcemaps total** | **34MB — 68% of the tarball** |
| javascript | 15MB |
| **unpacked** | **50.0MB** |

Every `npx @blockrun/clawrouter`, every OpenClaw plugin install, and every package that depends on us pays that.

## What

`"!dist/**/*.map"` in package.json `files`.

**50.0MB → 16.6MB unpacked** (3.4MB packed, 41 files).

`sourcemap: true` stays in `tsup.config.ts` — maps are still generated for local debugging and CI, they just don't ship. The bundles keep their `//# sourceMappingURL=` comment; a missing map is silently ignored at runtime.

## Verified

Installed the packed tarball fresh:

```
16M   on disk (was 50M)
✓ no .map files shipped
✓ dist/cli.js --version           → 0.12.224
✓ node --enable-source-maps ...   → 0.12.224   (missing map does not crash)
```

No behaviour change.

## Context

Found while auditing why `@blockrun/mcp` was paying ~50MB — about **15% of its whole 328MB install tree** — for a router it never called. See [blockrun-llm-ts#11](https://github.com/BlockRunAI/blockrun-llm-ts/pull/11), which stops installing ClawRouter for consumers that don't route. This change cuts the cost for everyone who *does* install it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 0.12.224.
  * Reduced the npm package size by excluding source map files from published distributions.
  * Source maps remain available for local and CI debugging.
  * Runtime behavior is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->