### PR TITLE
feat(models): add Qwen3.7 Max

### DIFF
--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -70,6 +70,22 @@ describe("resolveModelAlias", () => {
     expect(BLOCKRUN_MODELS.some((m) => m.id === "anthropic/claude-sonnet-4.5")).toBe(true);
     expect(resolveModelAlias("sonnet")).toBe("anthropic/claude-sonnet-4.6");
   });
+
+  it("registers Qwen3.7 Max with its public aliases and gateway pricing", () => {
+    const qwen = BLOCKRUN_MODELS.find((model) => model.id === "qwen/qwen3.7-max");
+
+    expect(qwen).toMatchObject({
+      name: "Qwen3.7 Max",
+      inputPrice: 1.475,
+      outputPrice: 4.425,
+      contextWindow: 1_000_000,
+      maxOutput: 65_536,
+      reasoning: true,
+      toolCalling: true,
+    });
+    expect(resolveModelAlias("qwen")).toBe("qwen/qwen3.7-max");
+    expect(resolveModelAlias("qwen3.7-max")).toBe("qwen/qwen3.7-max");
+  });
 });
 
 describe("OPENCLAW_MODELS integrity", () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -103,6 +103,12 @@ export const MODEL_ALIASES: Record<string, string> = {
   "kimi-k2.5": "moonshot/kimi-k2.5",
   "nvidia/kimi-k2.5": "moonshot/kimi-k2.5",
 
+  // Qwen — Qwen3.7 Max is Alibaba's current flagship for reasoning, coding,
+  // and agentic tool use.
+  qwen: "qwen/qwen3.7-max",
+  "qwen3.7-max": "qwen/qwen3.7-max",
+  "qwen-3.7-max": "qwen/qwen3.7-max",
+
   // Google
   // gemini-3-pro-preview delisted by Google 2026-06-06 — mirror the gateway
   // redirect to its successor so pinned callers land on 3.1-pro, not an error.
@@ -888,6 +894,22 @@ export const BLOCKRUN_MODELS: BlockRunModel[] = [
     maxOutput: 65536,
     reasoning: true,
     vision: true,
+    agentic: true,
+    toolCalling: true,
+  },
+
+  // Qwen3.7 Max — BlockRun's paid Qwen flagship, served through its
+  // OpenRouter credit pool. The gateway applies its standard 5% margin at
+  // settlement, so keep the catalog rates at the upstream $1.475/$4.425 COGS.
+  {
+    id: "qwen/qwen3.7-max",
+    name: "Qwen3.7 Max",
+    version: "3.7-max",
+    inputPrice: 1.475,
+    outputPrice: 4.425,
+    contextWindow: 1000000,
+    maxOutput: 65536,
+    reasoning: true,
     agentic: true,
     toolCalling: true,
   },

--- a/src/top-models.json
+++ b/src/top-models.json
@@ -21,6 +21,7 @@
   "deepseek/deepseek-chat",
   "deepseek/deepseek-reasoner",
   "moonshot/kimi-k2.7",
+  "qwen/qwen3.7-max",
   "xai/grok-4.3",
   "xai/grok-build-0.1",
   "xai/grok-3",


### PR DESCRIPTION
## Summary

- Add Qwen3.7 Max to the ClawRouter catalog and curated top-model list.
- Add `qwen`, `qwen3.7-max`, and `qwen-3.7-max` aliases.
- Preserve gateway pricing at raw $1.475/$4.425 per million tokens; settlement applies BlockRun's standard margin.

## Validation

- `npm test -- --run src/models.test.ts src/top-models.test.ts src/proxy.models-endpoint.test.ts`
- `npm run typecheck`
