### PR TITLE
fix(readme): the tier table disagreed with the router it documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Every other LLM router was built for **human developers** — create an account,
 
 ClawRouter is built for the agent-first world:
 
-- **Starts at $0** — <!-- br:models.free -->8<!-- /br:models.free --> NVIDIA models are free forever (incl. 675B Mistral Large 3, 262K-context Qwen3-Next 80B + a vision-capable Nemotron Omni)
+- **Starts at $0** — <!-- br:models.free -->8<!-- /br:models.free --> NVIDIA models are free forever (incl. 262K-context Qwen3-Next 80B, DeepSeek V4 Flash + a vision-capable Nemotron Omni)
 - **No accounts** — a wallet is generated locally, no signup
 - **No API keys** — your wallet signature IS authentication
 - **No model selection** — <!-- br:clawrouter.dimensions -->15<!-- /br:clawrouter.dimensions -->-dimension scoring picks the right model automatically
@@ -78,7 +78,7 @@ This is the stack that lets agents operate autonomously: **x402 + USDC + local r
 
 ## Quick Start
 
-> **No wallet? <!-- br:models.free -->8<!-- /br:models.free --> models work free out of the box.** Install, run, and pin `free/mistral-large-3-675b` (or any of the <!-- br:models.free -->8<!-- /br:models.free -->) — no crypto, no signup, no balance required. Add USDC later when you want paid models.
+> **No wallet? <!-- br:models.free -->8<!-- /br:models.free --> models work free out of the box.** Install, run, and pin `free/mistral-nemotron` (or any of the <!-- br:models.free -->8<!-- /br:models.free -->) — no crypto, no signup, no balance required. Add USDC later when you want paid models.
 
 ### Option A — OpenClaw Agent
 
@@ -118,7 +118,7 @@ npx @blockrun/clawrouter
 ```
 
 **2. Fund your wallet** — optional, skip for free tier
-Your wallet address is printed on first run. For paid models, send a few USDC on Base or Solana — $5 covers thousands of requests. To stay at $0, pin any of the <!-- br:models.free -->8<!-- /br:models.free --> free models (e.g. `free/mistral-large-3-675b`) or use `/model free` inside OpenClaw.
+Your wallet address is printed on first run. For paid models, send a few USDC on Base or Solana — $5 covers thousands of requests. To stay at $0, pin any of the <!-- br:models.free -->8<!-- /br:models.free --> free models (e.g. `free/mistral-nemotron`) or use `/model free` inside OpenClaw.
 
 **3. Point your client at `http://localhost:8402`**
 
@@ -188,12 +188,14 @@ response = client.chat.completions.create(model="blockrun/auto", messages=[...])
 
 Choose your routing strategy with `/model <profile>`:
 
-| Profile          | Strategy           | Savings                                                                            | Best For             |
-| ---------------- | ------------------ | ---------------------------------------------------------------------------------- | -------------------- |
-| `/model free`    | Free NVIDIA models | **100%**                                                                           | $0 balance, learning |
-| `/model auto`    | Balanced (default) | **<!-- br:savings.autoVsBaselinePct -->87<!-- /br:savings.autoVsBaselinePct -->%** | General use          |
-| `/model eco`     | Cheapest possible  | **<!-- br:savings.ecoVsBaselinePct -->98<!-- /br:savings.ecoVsBaselinePct -->%**   | Maximum savings      |
-| `/model premium` | Best quality       | 0%                                                                                 | Mission-critical     |
+| Profile       | Strategy           | Savings                                                                                                                                                                                                                                                                                           | Best For             |
+| ------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `/model free` | Free NVIDIA models | **100%**                                                                                                                                                                                                                                                                                          | $0 balance, learning |
+| `/model auto` | Balanced (default) | † Withheld from `/v1/models` — the router still calls it by direct ID, but you will not find it on the public pricing page. See [savings-mix.json](https://github.com/BlockRunAI/blockrun/blob/main/src/brand/savings-mix.json), which prices the published savings claim on visible models only. |
+
+**<!-- br:savings.autoVsBaselinePct -->87<!-- /br:savings.autoVsBaselinePct -->%** | General use |
+| `/model eco` | Cheapest possible | **<!-- br:savings.ecoVsBaselinePct -->98<!-- /br:savings.ecoVsBaselinePct -->%** | Maximum savings |
+| `/model premium` | Best quality | 0% | Mission-critical |
 
 **Shortcuts:** `/model grok`, `/model br-sonnet`, `/model gpt5`, `/model o3`
 
@@ -207,12 +209,12 @@ Choose your routing strategy with `/model <profile>`:
 Request → Weighted Scorer (<!-- br:clawrouter.dimensions -->14<!-- /br:clawrouter.dimensions --> dimensions) → Tier → Best Model → Response
 ```
 
-| Tier      | ECO Model                            | AUTO Model                      | PREMIUM Model                |
-| --------- | ------------------------------------ | ------------------------------- | ---------------------------- |
-| SIMPLE    | free/mistral-large-3-675b (**FREE**) | gemini-2.5-flash ($0.30/$2.50)  | kimi-k2.7 ($0.95/$4.00)      |
-| MEDIUM    | gemini-3.1-flash-lite ($0.25/$1.50)  | kimi-k2.7 ($0.95/$4.00)         | gpt-5.3-codex ($1.75/$14.00) |
-| COMPLEX   | gemini-3.1-flash-lite ($0.25/$1.50)  | gemini-3.1-pro ($2/$12)         | claude-fable-5 ($10/$50)     |
-| REASONING | deepseek-reasoner ($0.20/$0.40)      | deepseek-reasoner ($0.20/$0.40) | claude-sonnet-4.6 ($3/$15)   |
+| Tier      | ECO Model                               | AUTO Model                              | PREMIUM Model                |
+| --------- | --------------------------------------- | --------------------------------------- | ---------------------------- |
+| SIMPLE    | free/gpt-oss-120b † (**FREE**)          | gemini-2.5-flash ($0.30/$2.50)          | kimi-k2.7 † ($0.95/$4.00)    |
+| MEDIUM    | gemini-3.1-flash-lite ($0.25/$1.50)     | kimi-k2.7 ($0.95/$4.00)                 | gpt-5.3-codex ($1.75/$14.00) |
+| COMPLEX   | gemini-3.1-flash-lite ($0.25/$1.50)     | gemini-3.1-pro ($2/$12)                 | claude-fable-5 ($10/$50)     |
+| REASONING | grok-4-1-fast-reasoning † ($0.20/$0.50) | grok-4-1-fast-reasoning † ($0.20/$0.50) | claude-sonnet-4.6 ($3/$15)   |
 
 **<!-- br:savings.autoVsBaselinePct -->87<!-- /br:savings.autoVsBaselinePct -->% cheaper than pinning Claude Opus 5** for the same traffic, on `auto`; **<!-- br:savings.ecoVsBaselinePct -->98<!-- /br:savings.ecoVsBaselinePct -->%** on `eco`.
 

--- a/src/router/brand-numbers.test.ts
+++ b/src/router/brand-numbers.test.ts
@@ -103,3 +103,35 @@ describe("README hero badge", () => {
     expect(readme).toContain(`alt="${free} free models"`);
   });
 });
+
+describe("README tier table", () => {
+  // The table names one model per tier per profile. It had drifted three cells
+  // out of config.ts — eco SIMPLE and both REASONING primaries — and nothing
+  // noticed, because a README is prose to everything except a reader.
+  //
+  // Matched on the model's short name rather than the full id: the table is
+  // written for humans and drops the provider prefix.
+  const readme = readFileSync("README.md", "utf8");
+  // End at the footnote line, not the first "†" — that character also appears
+  // inside the table, marking primaries withheld from /v1/models.
+  const table = readme.slice(readme.indexOf("| Tier "), readme.indexOf("\n† Withheld"));
+
+  const shortName = (id: string) => id.split("/")[1];
+  const profiles = [
+    ["ecoTiers", "ECO"],
+    ["tiers", "AUTO"],
+    ["premiumTiers", "PREMIUM"],
+  ] as const;
+
+  for (const [key, label] of profiles) {
+    for (const tier of ["SIMPLE", "MEDIUM", "COMPLEX", "REASONING"] as const) {
+      it(`${label} ${tier} names the configured primary`, () => {
+        const table_ = DEFAULT_ROUTING_CONFIG[key] as Record<string, { primary: string }>;
+        const primary = shortName(table_[tier].primary);
+        const row = table.split("\n").find((l) => l.startsWith(`| ${tier}`));
+        expect(row, `no ${tier} row in the README table`).toBeDefined();
+        expect(row).toContain(primary);
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Three of twelve cells were wrong

| Cell | README said | `config.ts` routes to |
|---|---|---|
| ECO SIMPLE | `free/mistral-large-3-675b` | **`free/gpt-oss-120b`** |
| ECO REASONING | `deepseek-reasoner` | **`xai/grok-4-1-fast-reasoning`** |
| AUTO REASONING | `deepseek-reasoner` | **`xai/grok-4-1-fast-reasoning`** |

Nothing caught it, because a README is prose to everything except a reader.

`src/router/brand-numbers.test.ts` now reads the table and compares **every cell** against `DEFAULT_ROUTING_CONFIG`, so the doc fails the build instead of the reader. Verified it catches the original drift: restoring `free/mistral-large-3-675b` fails with `ECO SIMPLE names the configured primary`.

## The quick start pointed at a model users cannot find

Three places told readers to pin `free/mistral-large-3-675b` as one of the eight free models:

> **No wallet? 8 models work free out of the box.** Install, run, and pin `free/mistral-large-3-675b` (or any of the 8)

It is **not one of the eight**. It is `hidden: true` in the gateway catalog — withheld from `/v1/models` over NVIDIA's prompt-retention terms — so someone following that instruction pins a model that does not appear in the catalog they were just told to browse.

The eight actually published are all `nvidia/*`: `deepseek-v4-flash`, `nemotron-3-nano-omni-30b-a3b-reasoning`, `qwen3-next-80b-a3b-instruct`, `mistral-nemotron`, `step-3.7-flash`, `seed-oss-36b`, `nemotron-nano-9b-v2`, `nemotron-nano-12b-v2-vl`.

Swapped the example for `free/mistral-nemotron`, and dropped "675B Mistral Large 3" from the `incl.` list for the same reason.

## Withheld primaries now carry a footnote

The corrected table names two models that `/v1/models` does not list, so it says so:

> † Withheld from `/v1/models` — the router still calls it by direct ID, but you will not find it on the public pricing page.

That is the honest shape. The router does call them; a reader should not go hunting for them on the pricing page. It is also exactly why the published savings figure is priced on visible models only.

## Not a routing bug

`free/gpt-oss-120b` is `available: true, hidden: true` — callable by direct ID, deliberately absent from the public catalog. The router works; only the documentation was wrong.

## Verification

`tsc` clean · prettier clean · 722 tests pass · `sync-brand-numbers --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated model examples and Quick Start instructions to reflect current free model options.
  * Refreshed routing profile details, tier-to-model mappings, and pricing information.

* **Tests**
  * Added validation to ensure the README’s routing tables stay aligned with configured models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->