### PR TITLE
fix: the skill shipped to agents was the stalest surface of all

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ You're here. <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> mod
 
 **BlockRun for Claude Code**
 
-Run Claude Code with 50+ models, no rate limits, no Anthropic account, no phone verification. Pay per request with USDC — your wallet is your identity.
+Run Claude Code with <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models, no rate limits, no Anthropic account, no phone verification. Pay per request with USDC — your wallet is your identity.
 
 `curl -fsSL https://blockrun.ai/brcc-install | bash`
 

--- a/skills/clawrouter/SKILL.md
+++ b/skills/clawrouter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawrouter
-description: Hosted-gateway LLM router — save 67% on inference costs. A local proxy that forwards each request to the blockrun.ai gateway, which routes to the cheapest capable model across 55+ models from OpenAI, Anthropic, Google, DeepSeek, xAI, NVIDIA, and more. 8 free NVIDIA models included. Also exposes realtime market data (global stocks, crypto, FX, commodities), Twitter/X intelligence, prediction-market data across Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, dFlow + UMA oracle resolution + wallet identity & clustering, phone-number intelligence (carrier + SIM-swap fraud detection) plus AI-powered outbound voice calls (Twilio + Bland.ai), AND the Surf unified crypto data API (84 endpoints — CEX/DEX, on-chain SQL over 80+ ClickHouse tables, 100M+ labeled wallets, prediction markets, social/CT mindshare, news, VC fund intel) as built-in agent tools. Not a local-inference tool — prompts are sent to the blockrun.ai gateway.
+description: Hosted-gateway LLM router — save 87% on inference costs. A local proxy that forwards each request to the blockrun.ai gateway, which routes to the cheapest capable model across 66 models from OpenAI, Anthropic, Google, DeepSeek, xAI, NVIDIA, and more. 8 free NVIDIA models included. Also exposes realtime market data (global stocks, crypto, FX, commodities), Twitter/X intelligence, prediction-market data across Polymarket, Kalshi, Limitless, Opinion, Predict.Fun, dFlow + UMA oracle resolution + wallet identity & clustering, phone-number intelligence (carrier + SIM-swap fraud detection) plus AI-powered outbound voice calls (Twilio + Bland.ai), AND the Surf unified crypto data API (84 endpoints — CEX/DEX, on-chain SQL over 80+ ClickHouse tables, 100M+ labeled wallets, prediction markets, social/CT mindshare, news, VC fund intel) as built-in agent tools. Not a local-inference tool — prompts are sent to the blockrun.ai gateway.
 triggers:
   - "clawrouter"
   - "claw router"
@@ -53,7 +53,7 @@ metadata:
 
 # ClawRouter
 
-Hosted-gateway LLM router that saves 67% on inference costs by forwarding each request to the blockrun.ai gateway, which picks the cheapest model capable of handling it across 55+ models from 9 providers (8 free NVIDIA models). All billing flows through one USDC wallet; you do not hold provider API keys.
+Hosted-gateway LLM router that saves <!-- br:savings.autoVsBaselinePct -->87<!-- /br:savings.autoVsBaselinePct -->% on inference costs by forwarding each request to the blockrun.ai gateway, which picks the cheapest model capable of handling it across <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models from 9 providers (<!-- br:models.free -->8<!-- /br:models.free --> free NVIDIA models). All billing flows through one USDC wallet; you do not hold provider API keys.
 
 **This is not a local-inference tool.** ClawRouter is a thin local proxy. Your prompts are sent over HTTPS to the blockrun.ai gateway for model execution. If your workload requires inference that never leaves your machine, use a local runtime like Ollama — ClawRouter is not the right tool for that use case.
 
@@ -126,16 +126,22 @@ openclaw models set openai/gpt-4o
 
 ClawRouter classifies each request into one of four tiers:
 
-- **SIMPLE** (40% of traffic) — factual lookups, greetings, translations → Gemini Flash ($0.60/M, 99% savings)
-- **MEDIUM** (30%) — summaries, explanations, data extraction → DeepSeek Chat ($0.42/M, 99% savings)
-- **COMPLEX** (20%) — code generation, multi-step analysis → Claude Opus ($75/M, best quality)
-- **REASONING** (10%) — proofs, formal logic, multi-step math → o3 ($8/M, 89% savings)
+- **SIMPLE** — factual lookups, greetings, translations → gemini-2.5-flash ($0.30/$2.50)
+- **MEDIUM** — summaries, explanations, data extraction → kimi-k2.7 ($0.95/$4.00)
+- **COMPLEX** — code generation, multi-step analysis → gemini-3.1-pro ($2/$12)
+- **REASONING** — proofs, formal logic, multi-step math → grok-4-1-fast-reasoning ($0.20/$0.50)
+
+Prices are per 1M input/output tokens, on the default `auto` profile. Per-tier
+savings percentages are deliberately not quoted here: the published figure is
+blended across a stated workload mix, and a per-tier number invites comparing
+it against a baseline nobody wrote down. See
+[savings-mix.json](https://github.com/BlockRunAI/blockrun/blob/main/src/brand/savings-mix.json).
 
 Rules handle ~~80% of requests in <1ms. Only ambiguous queries hit the LLM classifier (~~$0.00003 per classification).
 
 ## Available Models
 
-55+ models including: gpt-5.6-terra [balanced, stable default], gpt-5.6-sol [flagship], gpt-5.6-luna [cost-efficient], gpt-5.5, gpt-5.5-pro [max compute], chat-latest [ChatGPT Instant], gpt-5.4, gpt-4o, o3, claude-fable-5, claude-opus-5 [Anthropic flagship, 1M ctx], claude-opus-4.8, claude-opus-4.7, claude-opus-4.5, claude-sonnet-5, claude-sonnet-4.6, gemini-3.1-pro, gemini-2.5-flash, deepseek-v4-pro, deepseek-chat, grok-4.5, grok-4.3, grok-build-0.1, kimi-k3 [1M ctx flagship], kimi-k2.7, qwen3.7-max [Qwen flagship, 1M ctx], and 8 free NVIDIA models (mistral-large-3-675b [default, 675B flagship], deepseek-v4-flash [1M context], seed-oss-36b [coding], nemotron-3-nano-omni-30b-a3b-reasoning [vision], mistral-nemotron, step-3.7-flash, nemotron-nano-9b-v2, nemotron-nano-12b-v2-vl [vision]).
+<!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models including: gpt-5.6-terra [balanced, stable default], gpt-5.6-sol [flagship], gpt-5.6-luna [cost-efficient], gpt-5.5, gpt-5.5-pro [max compute], chat-latest [ChatGPT Instant], gpt-5.4, gpt-4o, o3, claude-fable-5, claude-opus-5 [Anthropic flagship, 1M ctx], claude-opus-4.8, claude-opus-4.7, claude-opus-4.5, claude-sonnet-5, claude-sonnet-4.6, gemini-3.1-pro, gemini-2.5-flash, deepseek-v4-pro, deepseek-chat, grok-4.5, grok-4.3, grok-build-0.1, kimi-k3 [1M ctx flagship], kimi-k2.7, qwen3.7-max [Qwen flagship, 1M ctx], and 8 free NVIDIA models (mistral-large-3-675b [default, 675B flagship], deepseek-v4-flash [1M context], seed-oss-36b [coding], nemotron-3-nano-omni-30b-a3b-reasoning [vision], mistral-nemotron, step-3.7-flash, nemotron-nano-9b-v2, nemotron-nano-12b-v2-vl [vision]).
 
 ## Built-in Agent Tools
 

--- a/src/router/brand-numbers.test.ts
+++ b/src/router/brand-numbers.test.ts
@@ -135,3 +135,23 @@ describe("README tier table", () => {
     }
   }
 });
+
+describe("skill frontmatter", () => {
+  // A skill's YAML frontmatter is the description an agent reads when deciding
+  // whether to load it. A marker there is not inert — it becomes part of the
+  // string — so it holds literals, asserted here like package.json is.
+  const skill = readFileSync("skills/clawrouter/SKILL.md", "utf8");
+  const frontmatter = skill.slice(0, skill.indexOf("\n---", 4));
+  const n = JSON.parse(readFileSync("brand-numbers.json", "utf8")) as {
+    models: { chatVisible: number };
+    savings: { autoVsBaselinePct: number };
+  };
+
+  it("quotes the published savings figure", () => {
+    expect(frontmatter).toContain(`save ${n.savings.autoVsBaselinePct}% on inference costs`);
+  });
+
+  it("quotes the published model count", () => {
+    expect(frontmatter).toContain(`${n.models.chatVisible} models`);
+  });
+});


### PR DESCRIPTION
Found by sweeping for the **shape** of a claim — a number in front of the claim vocabulary — rather than for phrasings anyone remembered. Three earlier passes over these repos had each grepped differently and each missed a different subset.

## What was stale

See the commit for the per-file list. All values now come from the published artifact, and `sync-brand-numbers --check` is clean outside `CHANGELOG.md`, which is history and stays as written.

## Frontmatter takes literals, not markers

A `SKILL.md` YAML `description:` is a string an agent reads when deciding whether to load the skill — an HTML comment there is part of the string, not invisible. Same for headings, where it leaks into the anchor slug. Those counts are asserted in the test suite instead, the same trade already made for `package.json` and the shields badges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ecosystem and router messaging to reflect current model availability, savings, access requirements, and payment details.
  * Added updated tier pricing information and clarified that tier savings are not directly quoted.

* **Tests**
  * Added checks to ensure published savings and model counts remain consistent across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->