### PR TITLE
docs: correct the evergreen posts, date-stamp the ones that are measurements

### DIFF
--- a/docs/9-free-ai-models-zero-cost-blockrun.md
+++ b/docs/9-free-ai-models-zero-cost-blockrun.md
@@ -1,5 +1,11 @@
 # 9 Free AI Models, Zero Cost: How BlockRun Gives Developers Top-Tier LLMs for Nothing
 
+> **The count in this title is a snapshot.** It was 9 when this was written; the
+> published free tier is now 8 — models are withheld from `/v1/models` when a
+> provider's terms change, most recently over NVIDIA's prompt-retention policy.
+> The URL keeps its original slug so existing links do not break. Current figures:
+> [blockrun.ai/brand/numbers.json](https://blockrun.ai/brand/numbers.json).
+
 ## The Cost Problem Nobody Talks About
 
 It's 2026. Large language models are table stakes for developers. But here's the uncomfortable truth — **the models you can afford aren't good enough, and the good ones aren't affordable.**
@@ -80,7 +86,7 @@ Assume 100 requests per day, distributed roughly as:
 | ClawRouter ECO mode         | ~$1–3                  |
 | Manual free model selection | **$0**                 |
 
-**ECO mode saves 92%+ compared to Claude Opus alone.**
+**ECO mode is <!-- br:savings.ecoVsBaselinePct -->98<!-- /br:savings.ecoVsBaselinePct -->% cheaper than pinning Claude Opus 5 for every request.**
 
 ---
 

--- a/docs/anthropic-cost-savings.md
+++ b/docs/anthropic-cost-savings.md
@@ -50,7 +50,7 @@ This is where you're paying for real value:
 
 ## The Solution: ClawRouter
 
-[ClawRouter](https://github.com/BlockRunAI/ClawRouter) is an open-source local proxy that sits between your app and 41+ AI models. It saves you money in three ways: **smart routing**, **token optimization**, and **response caching**.
+[ClawRouter](https://github.com/BlockRunAI/ClawRouter) is an open-source local proxy that sits between your app and <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> AI models. It saves you money in three ways: **smart routing**, **token optimization**, and **response caching**.
 
 ```
 ┌─────────────┐     ┌──────────────────────────────┐     ┌──────────────────┐

--- a/docs/anthropic-third-party-harness-changes.md
+++ b/docs/anthropic-third-party-harness-changes.md
@@ -31,7 +31,7 @@ This is exactly the problem [ClawRouter](https://github.com/BlockRunAI/ClawRoute
 
 ## ClawRouter: Smart Routing for Agents
 
-ClawRouter is an open-source local proxy that sits between your agent and 55+ LLM models across 9 providers. It analyzes every request across 15 dimensions and routes it to the cheapest model that can handle it — in under 1ms, entirely locally.
+ClawRouter is an open-source local proxy that sits between your agent and <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> LLM models across 9 providers. It analyzes every request across 15 dimensions and routes it to the cheapest model that can handle it — in under 1ms, entirely locally.
 
 ```
 Your Agent → ClawRouter (localhost:8402) → Best model for the job
@@ -56,7 +56,7 @@ From 20,000+ production requests:
 | Free models (trivial tasks)      | 12.8%        | $0.00             |
 | Others                           | 13.8%        | varies            |
 
-**Result: 81% savings vs. Sonnet-for-everything, 89% vs. Opus-for-everything.**
+**Result: <!-- br:savings.autoVsBaselinePct -->87<!-- /br:savings.autoVsBaselinePct -->% cheaper than pinning Claude Opus 5 for every request** — the published figure, priced on a stated workload mix rather than estimated.
 
 A typical user running 10K mixed requests/month:
 
@@ -74,7 +74,7 @@ Then point your agent at `http://localhost:8402/v1/` with any OpenAI-compatible 
 
 - **No API keys to manage** — wallet-based cryptographic auth
 - **No subscriptions** — pay per request in USDC (Base or Solana)
-- **No vendor lock-in** — 55+ models, switch anytime
+- **No vendor lock-in** — <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models, switch anytime
 - **You control your wallet** — non-custodial, funds never held by a third party
 - **Budget caps** — set a max spend per session, ClawRouter gracefully downgrades when budget runs low
 - **Token compression** — 7-layer pipeline reduces token costs by 7–40% before they hit any provider

--- a/docs/clawrouter-cuts-llm-api-costs-500x.md
+++ b/docs/clawrouter-cuts-llm-api-costs-500x.md
@@ -135,7 +135,7 @@ Less context repeated = fewer tokens = lower cost. Agents that need to recall ea
 
 ### 7. x402 Micropayments — Wallet-Based Budget Control
 
-<p align="center"><img src="assets/blockrun-clawrouter-x402-usdc-micropayment-wallet-budget-control.png" alt="Budget limits enforced by physical construction — wallet loaded via Base/Solana, pay per call across 41+ models, balance hits zero and the valve shuts cleanly" width="720"></p>
+<p align="center"><img src="assets/blockrun-clawrouter-x402-usdc-micropayment-wallet-budget-control.png" alt="Budget limits enforced by physical construction — wallet loaded via Base/Solana, pay per call across <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models, balance hits zero and the valve shuts cleanly" width="720"></p>
 
 ClawRouter pays for inference via [x402](https://x402.org/) USDC micropayments (Base or Solana). You load a wallet. Each inference call costs exactly what it costs. When the wallet runs low, requests stop cleanly.
 
@@ -144,7 +144,7 @@ There is no monthly invoice. There is no 3am email. There is a wallet balance, a
 **`maxCostPerRun`** — a per-session cost ceiling that stops or downgrades requests once a session exceeds a configured threshold (e.g., `$0.50`). This closes the remaining gap ([#3181](https://github.com/openclaw/openclaw/issues/3181)) where a wallet with sufficient funds can still accumulate within a single run. Two modes: `graceful` (downgrade to cheaper models) and `strict` (hard 429 once the cap is hit).
 
 ```
-41+ models. One wallet. Pay per call.
+<!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models. One wallet. Pay per call.
 ```
 
 ---

--- a/docs/clawrouter-vs-openrouter-llm-routing-comparison.md
+++ b/docs/clawrouter-vs-openrouter-llm-routing-comparison.md
@@ -222,7 +222,7 @@ OpenRouter doesn't always pass through provider-specific features correctly. Ima
 
 **Direct provider routing.** ClawRouter routes through BlockRun's API directly to providers — not through a second aggregator. One hop, not two. Provider-specific features work because there's no middleman translating them.
 
-![Guaranteed Feature Parity & Direct Connectivity — Three-panel diagram: Vision (image_url auto-detected → vision-capable models only), Tool Calling (toolCalling flag → agentic models only), Catalog (curated 55+ models with automatic legacy-to-modern redirects). Direct provider routing means no dropped payloads.](./assets/clawrouter-feature-parity-direct-connectivity.png)
+![Guaranteed Feature Parity & Direct Connectivity — Three-panel diagram: Vision (image_url auto-detected → vision-capable models only), Tool Calling (toolCalling flag → agentic models only), Catalog (curated <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models with automatic legacy-to-modern redirects). Direct provider routing means no dropped payloads.](./assets/clawrouter-feature-parity-direct-connectivity.png)
 
 ---
 
@@ -240,7 +240,7 @@ When new models launch, OpenRouter's catalog lags. Users configure a model that 
 
 ### How ClawRouter Solves This
 
-ClawRouter maintains a curated catalog of 55+ models across 9 providers (including 9 free models), updated with each release. Delisted models have automatic redirect aliases:
+ClawRouter maintains a curated catalog of <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models across 9 providers (including 9 free models), updated with each release. Delisted models have automatic redirect aliases:
 
 ```typescript
 // Delisted models redirect automatically
@@ -256,22 +256,22 @@ No silent drops. No stale catalog. Models are benchmarked for speed, quality, an
 
 ## The Full Comparison
 
-|                     | OpenRouter                       | ClawRouter                                     |
-| ------------------- | -------------------------------- | ---------------------------------------------- |
-| **Authentication**  | API key (leak risk)              | Wallet signature (no keys)                     |
-| **Payment**         | Prepaid balance (custodial)      | Per-request USDC (non-custodial)               |
-| **Routing**         | Server-side black box            | Local 14-dim classifier, <1ms                  |
-| **Fallback**        | Often broken (20+ issues)        | 8-deep chains, per-model isolation             |
-| **Model IDs**       | Nested prefixes, mangling bugs   | Clean aliases, single format                   |
-| **Cost visibility** | None per-request                 | Headers + JSONL logs + `/stats`                |
-| **Empty wallet**    | Request fails                    | Auto-fallback to free tier                     |
-| **Rate limits**     | Per-key, shared                  | Per-wallet, independent                        |
-| **Vision support**  | Images sometimes dropped         | Auto-detected, vision-only fallback            |
-| **Tool calling**    | Silent failures with some models | Flag-based filtering, guaranteed support       |
-| **Model catalog**   | Laggy, silent drops              | Curated 55+ models, redirect aliases           |
-| **Budget control**  | Monthly invoice                  | Per-session cap (`maxCostPerRun`)              |
-| **Setup**           | Create account, paste key        | Agent generates wallet, auto-configured        |
-| **Average cost**    | $25/M tokens (Opus direct)       | $2.05/M tokens (auto-routed) = **92% savings** |
+|                     | OpenRouter                       | ClawRouter                                                                                               |
+| ------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Authentication**  | API key (leak risk)              | Wallet signature (no keys)                                                                               |
+| **Payment**         | Prepaid balance (custodial)      | Per-request USDC (non-custodial)                                                                         |
+| **Routing**         | Server-side black box            | Local 14-dim classifier, <1ms                                                                            |
+| **Fallback**        | Often broken (20+ issues)        | 8-deep chains, per-model isolation                                                                       |
+| **Model IDs**       | Nested prefixes, mangling bugs   | Clean aliases, single format                                                                             |
+| **Cost visibility** | None per-request                 | Headers + JSONL logs + `/stats`                                                                          |
+| **Empty wallet**    | Request fails                    | Auto-fallback to free tier                                                                               |
+| **Rate limits**     | Per-key, shared                  | Per-wallet, independent                                                                                  |
+| **Vision support**  | Images sometimes dropped         | Auto-detected, vision-only fallback                                                                      |
+| **Tool calling**    | Silent failures with some models | Flag-based filtering, guaranteed support                                                                 |
+| **Model catalog**   | Laggy, silent drops              | Curated <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> models, redirect aliases         |
+| **Budget control**  | Monthly invoice                  | Per-session cap (`maxCostPerRun`)                                                                        |
+| **Setup**           | Create account, paste key        | Agent generates wallet, auto-configured                                                                  |
+| **Average cost**    | $25/M tokens (Opus direct)       | auto-routed = **<!-- br:savings.autoVsBaselinePct -->87<!-- /br:savings.autoVsBaselinePct -->% savings** |
 
 ![The Engineering Matrix — Side-by-side feature comparison: OpenRouter vs ClawRouter across Routing, Authentication, Payment, Fallback, Model IDs, Empty Wallet, Vision/Tools, and Average Cost. ClawRouter wins on every dimension.](./assets/clawrouter-engineering-matrix-comparison.png)
 

--- a/docs/llm-router-benchmark-46-models-sub-1ms-routing.md
+++ b/docs/llm-router-benchmark-46-models-sub-1ms-routing.md
@@ -2,6 +2,11 @@
 
 _March 16, 2026 | BlockRun Engineering_
 
+> **Numbers in this post are a snapshot from the date above.** They record what was
+> measured then and are deliberately not updated — rewriting them would misrepresent
+> the benchmark. For current figures see
+> [blockrun.ai/brand/numbers.json](https://blockrun.ai/brand/numbers.json).
+
 Last week we ran every model on BlockRun through a real-world latency benchmark — 39 models, same prompts, same payment pipeline, same hardware. No cherry-picked results. No synthetic lab conditions. Just cold, hard numbers from production infrastructure.
 
 The results changed how we route requests.

--- a/docs/smart-llm-router-14-dimension-classifier.md
+++ b/docs/smart-llm-router-14-dimension-classifier.md
@@ -2,6 +2,11 @@
 
 _March 20, 2026 | BlockRun Engineering_
 
+> **Numbers in this post are a snapshot from the date above.** They record what was
+> measured then and are deliberately not updated — rewriting them would misrepresent
+> the benchmark. For current figures see
+> [blockrun.ai/brand/numbers.json](https://blockrun.ai/brand/numbers.json).
+
 When you route AI requests across 55+ models from 8 providers, you can't just pick the cheapest one. You can't just pick the fastest one either. We learned this the hard way.
 
 This is the technical story of how we benchmarked every model on our platform, discovered that speed and intelligence are poorly correlated, and built a production routing system that classifies requests in under 1ms using 14 weighted dimensions with sigmoid confidence calibration.


### PR DESCRIPTION
`docs/` is **two different things** and had been treated as one.

## Evergreen pages — corrected

Comparisons, feature tables, the Anthropic cost posts. A reader takes these as current, and they were not:

| Claim | Was | Now |
|---|---|---|
| model count (5 places) | `55+` / `41+` | **66** |
| savings (comparison table) | `$2.05/M vs $25/M = 92%` | **87%**, published methodology |
| savings (harness post) | `89% vs Opus-for-everything` | **87%** |
| ECO savings (free-models post) | `92%+` | **98%** |

## Dated posts — left alone, and now say so

"We Benchmarked 39 AI Models Through Our Payment Gateway" ran **39 models on March 16**. Rewriting that to 66 would misrepresent what was measured, not update it.

Those keep their numbers and gain a note:

> **Numbers in this post are a snapshot from the date above.** They record what was measured then and are deliberately not updated — rewriting them would misrepresent the benchmark.

## The awkward one

`9-free-ai-models-zero-cost-blockrun.md` has the count in its **title and its URL**. The free tier is 8 now, not 9. Renaming breaks every existing link, so it takes the same note — which also explains *why* it moved: models get withheld when a provider's terms change, most recently NVIDIA's prompt-retention policy.

## Deliberately not "fixed"

The sweep flagged these; all are different subjects wearing the same words:

- `up to 97%` — observation **compression** ratio, not cost
- `3 models per request` — the fallback attempt cap
- `2 chains` — L1/L2, not RPC
- `up to 30%` — Anthropic's own promo credit

## Verification

`tsc` clean · prettier clean · 724 tests pass · `sync-brand-numbers --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated model availability claims across product and comparison pages to reflect 66 visible models.
  - Revised cost-savings figures to use current, dynamically calculated ECO-mode and auto-routing comparisons.
  - Clarified that model counts and benchmark metrics are time-stamped snapshots.
  - Added a link to the current JSON source for up-to-date figures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->