### PR TITLE
fix(models): mark MiniMax M3 vision-capable

### DIFF
--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -277,6 +277,15 @@ describe("capability flags vs blockrun's catalog", () => {
       expect(BLOCKRUN_MODELS.find((m) => m.id === id)?.vision).toBe(true);
     }
   });
+
+  it("marks MiniMax M3 vision-capable so image_url requests reach it", () => {
+    // The target metadata lists text+image+video input for MiniMax M3, but the
+    // model was registered without `vision`, so filterByVision() excluded it
+    // whenever a request carried an image_url content part. M2.7 is text-only
+    // upstream and must stay without the flag.
+    expect(BLOCKRUN_MODELS.find((m) => m.id === "minimax/minimax-m3")?.vision).toBe(true);
+    expect(BLOCKRUN_MODELS.find((m) => m.id === "minimax/minimax-m2.7")?.vision).toBeUndefined();
+  });
 });
 
 describe("OPENCLAW_MODELS integrity", () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -1358,6 +1358,7 @@ export const BLOCKRUN_MODELS: BlockRunModel[] = [
     contextWindow: 1048576,
     maxOutput: 65536,
     reasoning: true,
+    vision: true,
     agentic: true,
     toolCalling: true,
   },


### PR DESCRIPTION
Reason: MiniMax M3 is registered without the vision flag, so ClawRouter's existing image_url detection and vision-filter path exclude it even though the target metadata supports text, image, and video input.

## Changes
- Add `vision: true` to the `minimax/minimax-m3` entry in `src/models.ts` so `supportsVision()` returns true and `filterByVision()` keeps M3 in the candidate pool for requests that carry `image_url` content parts.
- Add a regression test in `src/models.test.ts` asserting M3 is vision-capable and M2.7 (text-only upstream) is not.

M2.7 is intentionally left without the flag; only M3 carries text+image+video input in the target metadata.

## Checks
- `npx tsc --noEmit`
- `npx vitest run src/models.test.ts`
- `npx prettier --check src/models.ts src/models.test.ts`
- `npx eslint src/models.ts src/models.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vision support for the MiniMax M3 model, enabling image-based requests.
* **Bug Fixes**
  * Corrected model capability detection so MiniMax M3 accepts image inputs while MiniMax M2.7 remains text-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->