### PR TITLE
fix(music): default to music-3.0 and list current models

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1261,8 +1261,8 @@ function buildMusicGenerationProvider(): MusicGenerationProviderPlugin {
   return {
     id: "blockrun",
     label: "BlockRun",
-    defaultModel: "minimax/music-2.5+",
-    models: ["minimax/music-2.5+", "minimax/music-2.5"],
+    defaultModel: "minimax/music-3.0",
+    models: ["minimax/music-3.0", "minimax/music-2.6", "minimax/music-3.0-free", "minimax/music-2.6-free"],
     capabilities: {
       maxTracks: 1,
       maxDurationSeconds: 240,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2769,7 +2769,7 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
           chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
         }
         const reqBody = Buffer.concat(chunks);
-        let audioModel = "minimax/music-2.5+";
+        let audioModel = "minimax/music-3.0";
         try {
           const parsed = JSON.parse(reqBody.toString());
           audioModel = parsed.model || audioModel;

--- a/test/test-e2e.ts
+++ b/test/test-e2e.ts
@@ -241,7 +241,7 @@ async function startMockUpstream(): Promise<MockUpstream> {
       const port = getListeningPort(server);
       writeJson(res, 200, {
         created: Math.floor(Date.now() / 1000),
-        model: "minimax/music-2.5+",
+        model: "minimax/music-3.0",
         data: [
           {
             url: `http://127.0.0.1:${port}/mock-assets/tiny.mp3`,
@@ -767,7 +767,7 @@ async function runLocalSuite(startProxy: StartProxy): Promise<boolean> {
     allPassed =
       (await runTest("Audio generation via mock upstream", async () => {
         const res = await postJson(proxy!, "/v1/audio/generations", {
-          model: "minimax/music-2.5+",
+          model: "minimax/music-3.0",
           prompt: "Short tone",
           instrumental: true,
           duration_seconds: 1,
@@ -979,12 +979,12 @@ async function runLiveSuite(startProxy: StartProxy): Promise<boolean> {
 
     if (RUN_MUSIC_TEST) {
       allPassed =
-        (await runTest("Live music generation (minimax/music-2.5+)", async () => {
+        (await runTest("Live music generation (minimax/music-3.0)", async () => {
           const res = await postJson(
             proxy!,
             "/v1/audio/generations",
             {
-              model: "minimax/music-2.5+",
+              model: "minimax/music-3.0",
               prompt: "Upbeat electronic music with a fast beat",
               instrumental: true,
               duration_seconds: 30,
@@ -1006,7 +1006,7 @@ async function runLiveSuite(startProxy: StartProxy): Promise<boolean> {
           return `(url=${audioUrl.split("/").pop()}, size=${(buf.byteLength / 1024).toFixed(0)}KB)`;
         })) && allPassed;
     } else {
-      skipTest("Live music generation (minimax/music-2.5+)", "set RUN_MUSIC_TEST=1");
+      skipTest("Live music generation (minimax/music-3.0)", "set RUN_MUSIC_TEST=1");
     }
   } finally {
     await proxy?.close();


### PR DESCRIPTION
Reason: refresh the MiniMax music provider to the current music-3.0 model and model list.

The runtime MiniMax music generation provider still defaulted to `minimax/music-2.5+` and advertised only the legacy `music-2.5` variants. This refreshes the registered default and model list to the current generation models.

Changes:
- `src/index.ts` (`buildMusicGenerationProvider`): default model is now `minimax/music-3.0` and the advertised `models` list now includes `minimax/music-3.0`, `minimax/music-2.6`, `minimax/music-3.0-free`, and `minimax/music-2.6-free`.
- `src/proxy.ts` (`/v1/audio/generations` handler): the fallback `audioModel` default is now `minimax/music-3.0`.
- `test/test-e2e.ts`: updated the mock upstream response and the local/live music fixtures to use `minimax/music-3.0`.

Checks run:
- `npx tsc --noEmit` — passed.
- `npx vitest run` — 723 passed / 3 skipped (one flaky lifecycle timeout passed on re-run; unrelated to this change).
- `npx tsx test/test-e2e.ts` — 20 passed / 0 failed (mocked audio generation path exercised with the refreshed model).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default music generation model to `minimax/music-3.0`.
  * Added support for `minimax/music-3.0`, `minimax/music-2.6`, and their free variants.

* **Bug Fixes**
  * Audio generation requests without a specified model now use the updated default model.

* **Tests**
  * Updated music generation test coverage to use the latest default model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->