### PR TITLE
chore(brand): refresh the snapshot — the markers were rendering a stale catalog

### DIFF
--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -3,11 +3,11 @@
   "version": 1,
   "models": {
     "chatVisible": 70,
-    "totalVisible": 93,
+    "totalVisible": 94,
     "free": 5,
     "freeWithheld": 20,
     "image": 9,
-    "video": 7,
+    "video": 8,
     "music": 1,
     "speech": 5,
     "soundfx": 1,


### PR DESCRIPTION
`brand-numbers.json` in this repo was behind the published artifact, so every `br:` marker here rendered a stale number.

The markers worked correctly — they rendered the input they had. `--check` is offline by design so PR CI stays deterministic, which means it validates against this repo's **own** snapshot; only `--refresh` updates that snapshot.

Opened automatically by [`brand/fanout-brand-numbers.mjs`](https://github.com/BlockRunAI/blockrun/blob/main/brand/fanout-brand-numbers.mjs). Produced by `--refresh`, no hand-edited digits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated model visibility counts to reflect one additional visible model.
  * Increased the visible video model count from 7 to 8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->