### PR TITLE
docs: BRCC links pointed at a 404 — use the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ openclaw gateway restart
 
 ### Option B — Standalone (continue.dev, Cursor, VS Code, any OpenAI-compatible client)
 
-> **Using Claude Code?** Check out [BRCC](https://blockrun.ai/brcc.md) — it's purpose-built for Claude Code with the same smart routing and x402 payments.
+> **Using Claude Code?** Check out [BRCC](https://github.com/BlockRunAI/brcc) — it's purpose-built for Claude Code with the same smart routing and x402 payments.
 >
 > **Using NousResearch Hermes?** See [ClawRouter-Hermes](https://github.com/BlockRunAI/ClawRouter-Hermes) — a Python plugin that wires Hermes into the ClawRouter proxy. Same wallet, same <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models, same x402 USDC settlement on Base & Solana.
 
@@ -674,7 +674,7 @@ You're here. <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> mod
 </td>
 <td width="50%">
 
-### 🤖 [BRCC](https://blockrun.ai/brcc.md)
+### 🤖 [BRCC](https://github.com/BlockRunAI/brcc)
 
 **BlockRun for Claude Code**
 


### PR DESCRIPTION
Both README mentions (and any docs copies) linked https://blockrun.ai/brcc.md;
that path has never resolved (404 today). The repo link redirects to the
current home of BRCC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Claude Code BRCC links in the standalone usage section and ecosystem table.
  * Links now point directly to the BRCC GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->