### PR TITLE
fix(proxy): guard image2image abort errors after client disconnect

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2739,6 +2739,7 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
           img2imgCost = estimateImageCost(img2imgModel, parsed.size, parsed.n || 1);
           reqBody = JSON.stringify(parsed);
         } catch (parseErr) {
+          if (clientAbort.signal.aborted) return;
           const msg = parseErr instanceof Error ? parseErr.message : String(parseErr);
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "Invalid request", details: msg }));
@@ -2818,6 +2819,7 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify(result));
         } catch (err) {
+          if (clientAbort.signal.aborted) return;
           const msg = err instanceof Error ? err.message : String(err);
           console.error(`[ClawRouter] Image editing error: ${msg}`);
           if (!res.headersSent) {


### PR DESCRIPTION
Closes #277.

Follow-up from #276 the `/v1/images/image2image` handler now returns silently when `clientAbort.signal.aborted` is true in both catch paths:

1. **Parse catch** (source/mask URL download): previously wrote a `400` to the closed socket when an abort interrupted the image/mask fetch.
2. **Outer catch** (`payFetch`): previously logged a bogus `Image editing error` and attempted a `502` response after client disconnect.

Non-abort errors retain their current `400` / `502` behavior only abort-caused exceptions are suppressed.

### Checklist
- [x] Repo forked and branch created from `main`
- [x] Commit messages and codestyle follow conventions
- [x] Relevant issues linked (#277)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary error responses when image-to-image requests are canceled by the client.
  - Improved handling of interrupted requests during request parsing and upstream processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->