### PR TITLE
chore(brand): refresh the snapshot — the markers were rendering a stale catalog

### DIFF
--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -18,7 +18,7 @@
     "dimensions": 15,
     "tiers": 4,
     "profiles": 4,
-    "aliases": 259
+    "aliases": 229
   },
   "mcp": {
     "tools": 20


### PR DESCRIPTION
`brand-numbers.json` in this repo was behind the published artifact, so every `br:` marker here rendered a stale number.

The markers worked correctly — they rendered the input they had. `--check` is offline by design so PR CI stays deterministic, which means it validates against this repo's **own** snapshot; only `--refresh` updates that snapshot.

Opened automatically by [`brand/fanout-brand-numbers.mjs`](https://github.com/BlockRunAI/blockrun/blob/main/brand/fanout-brand-numbers.mjs). Produced by `--refresh`, no hand-edited digits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the recorded `clawrouter.aliases` count from 259 to 229.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->