### PR TITLE
fix(stats): validate ?days window on /stats endpoint

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -69,7 +69,7 @@ import {
 } from "./models.js";
 import { DEFAULT_MAX_TOKENS, resolveMaxTokens } from "./max-tokens.js";
 import { logUsage, type UsageEntry } from "./logger.js";
-import { getStats, clearStats } from "./stats.js";
+import { getStats, clearStats, resolveStatsDays } from "./stats.js";
 import { RequestDeduplicator } from "./dedup.js";
 import { ResponseCache, type ResponseCacheConfig } from "./response-cache.js";
 import { BalanceMonitor } from "./balance.js";
@@ -2522,8 +2522,8 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
       if (req.url === "/stats" || req.url?.startsWith("/stats?")) {
         try {
           const url = new URL(req.url, "http://localhost");
-          const days = parseInt(url.searchParams.get("days") || "7", 10);
-          const stats = await getStats(Math.min(days, 30));
+          const days = resolveStatsDays(url.searchParams.get("days"));
+          const stats = await getStats(days);
 
           res.writeHead(200, {
             "Content-Type": "application/json",

--- a/src/stats.test.ts
+++ b/src/stats.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveStatsDays, DEFAULT_STATS_DAYS, MAX_STATS_DAYS } from "./stats.js";
+
+describe("resolveStatsDays", () => {
+  it("defaults to the standard window when no param is given", () => {
+    expect(resolveStatsDays(null)).toBe(DEFAULT_STATS_DAYS);
+    expect(resolveStatsDays(undefined)).toBe(DEFAULT_STATS_DAYS);
+    expect(resolveStatsDays("")).toBe(DEFAULT_STATS_DAYS);
+  });
+
+  it("passes a valid positive count through, clamped to the cap", () => {
+    expect(resolveStatsDays("1")).toBe(1);
+    expect(resolveStatsDays("7")).toBe(7);
+    expect(resolveStatsDays(String(MAX_STATS_DAYS))).toBe(MAX_STATS_DAYS);
+    expect(resolveStatsDays("31")).toBe(MAX_STATS_DAYS);
+    expect(resolveStatsDays("500")).toBe(MAX_STATS_DAYS);
+  });
+
+  // Moved from /tmp/clawrepro/stats-days.test.ts. A non-numeric param used to
+  // coerce to NaN, and Math.min(NaN, 30) stayed NaN, and getStats' slice(0, NaN)
+  // read as slice(0, 0) — so `?days=abc` reported zero usage instead of the
+  // default window.
+  it("falls back to the default for a non-numeric param instead of coercing to NaN", () => {
+    expect(resolveStatsDays("abc")).toBe(DEFAULT_STATS_DAYS);
+    expect(resolveStatsDays("   ")).toBe(DEFAULT_STATS_DAYS);
+  });
+
+  // A negative value survived Math.min, and getStats' slice(0, -1) dropped the
+  // newest day while the response mislabelled itself "last -1 days". Zero has the
+  // same shape. The `> 0` guard covers both.
+  it("rejects zero and negative windows, falling back to the default", () => {
+    expect(resolveStatsDays("0")).toBe(DEFAULT_STATS_DAYS);
+    expect(resolveStatsDays("-1")).toBe(DEFAULT_STATS_DAYS);
+    expect(resolveStatsDays("-30")).toBe(DEFAULT_STATS_DAYS);
+  });
+});

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -14,6 +14,32 @@ import { VERSION } from "./version.js";
 
 const LOG_DIR = join(homedir(), ".openclaw", "blockrun", "logs");
 
+/** Default reporting window when the request declares no usable `days`. */
+export const DEFAULT_STATS_DAYS = 7;
+/** Hard cap on the window — only this many daily log files are ever read. */
+export const MAX_STATS_DAYS = 30;
+
+/**
+ * Resolve the reporting window (`?days=`) for the /stats endpoint.
+ *
+ * The raw value is user-controlled, so it has to survive the ways JS silently
+ * coerces bad input into a number that changes behaviour. `parseInt("abc", 10)`
+ * is `NaN`, `Math.min(NaN, 30)` stays `NaN`, and `getStats`' `slice(0, NaN)`
+ * reads as `slice(0, 0)` — so a typo'd param reported zero usage instead of the
+ * default window. A negative value (`?days=-1`) survived `Math.min` and
+ * `slice(0, -1)` dropped the newest day while the response mislabelled itself
+ * "last -1 days". The single `Number.isFinite(parsed) && parsed > 0` guard
+ * covers non-numeric, NaN, zero, and negative alike; anything else falls back to
+ * the default. The result is clamped to MAX_STATS_DAYS.
+ */
+export function resolveStatsDays(raw: string | null | undefined): number {
+  const parsed = parseInt(raw ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_STATS_DAYS;
+  }
+  return Math.min(parsed, MAX_STATS_DAYS);
+}
+
 export type DailyStats = {
   date: string;
   totalRequests: number;


### PR DESCRIPTION
## What

`GET /stats?days=` parsed the user-controlled `days` param with `parseInt(url.searchParams.get("days") || "7", 10)` and then `Math.min(days, 30)`. Both steps pass bad input straight through JS's silent numeric coercion:

- **Non-numeric (`?days=abc`)** → `parseInt` returns `NaN` → `Math.min(NaN, 30)` stays `NaN` → `getStats(NaN)` → `logFiles.slice(0, NaN)` reads as `slice(0, 0)` → the endpoint reports **zero usage** instead of falling back to the default window.
- **Negative (`?days=-1`)** → survives `Math.min(-1, 30) = -1` → `slice(0, -1)` **drops the newest day**, and the response mislabels itself `"last -1 days"`.

Scope note: this is a **low-severity, read-only diagnostic endpoint** — it returns wrong/empty numbers on malformed input. It is **not** a security issue (no injection, no traversal, no auth impact); please don't read it as one.

## Fix

Add a small pure helper `resolveStatsDays(raw)` in `stats.ts` (mirroring the existing `resolveMaxTokens` precedent), with `DEFAULT_STATS_DAYS = 7` / `MAX_STATS_DAYS = 30`. A single guard handles every bad shape:

```ts
export function resolveStatsDays(raw: string | null | undefined): number {
  const parsed = parseInt(raw ?? "", 10);
  if (!Number.isFinite(parsed) || parsed <= 0) {
    return DEFAULT_STATS_DAYS;
  }
  return Math.min(parsed, MAX_STATS_DAYS);
}
```

`parsed <= 0` covers zero and negatives; `!Number.isFinite` covers non-numeric/`NaN`. The `/stats` handler now calls `resolveStatsDays(url.searchParams.get("days"))`.

## Tests (failing-first)

New `src/stats.test.ts` (4 cases: absent/default, valid+clamp, non-numeric, zero+negative).

- Against the pre-fix behavior: `"abc"` returned `NaN` and `"0"` returned `0` → **2 failed**.
- Against the fix: **4 passed**.
- `tsc --noEmit`, `prettier --check`, `eslint` all clean.
- Full suite: `794 passed`. The 2 unrelated failures on the tree (`router/brand-numbers`, `router/free-model-liveness`) are pre-existing catalog/brand-snapshot drift — confirmed by reproducing them with this change stashed. **Zero new failures.**

## Scope

Intentionally limited to the `/stats?days` coercion. No other changes bundled in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved statistics date-range handling for invalid, missing, zero, or negative values.
  - Statistics now use a consistent seven-day default when no valid range is provided.
  - Requests for longer periods are safely limited to a maximum of 30 days.
  - Valid positive date ranges continue to work as expected, providing more reliable statistics results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->