### PR TITLE
fix(spend-control): count in-flight reservations against hourly/daily caps under a live clock

### DIFF
--- a/src/spend-control.test.ts
+++ b/src/spend-control.test.ts
@@ -780,6 +780,52 @@ describe("x402 onBeforePaymentCreation spend policy", () => {
   });
 });
 
+describe("in-flight reservations under a live (non-frozen) clock", () => {
+  // Every other test in this file injects a FROZEN clock (`now: () => clock`, see
+  // createControl above): both clock reads inside a single check() return the same
+  // value, so a reservation is always counted and the race below cannot surface.
+  // Production uses Date.now(), which advances — when a millisecond ticks between
+  // the `now` check() captures at its top and the second `this.now()` the window
+  // helper used to read, the hourly/daily window silently dropped the pending
+  // total. This live clock (each read 1ms later) models that sub-ms advance so the
+  // concurrent-overspend path is actually exercised.
+  const liveClock = (startMs = 1_000_000_000_000) => {
+    let t = startMs;
+    return () => (t += 1);
+  };
+
+  it("counts an in-flight reservation against the hourly window while the clock advances mid-check", () => {
+    const control = new SpendControl({
+      storage: new InMemorySpendControlStorage(),
+      now: liveClock(),
+    });
+    control.setLimit("hourly", 1.0);
+
+    // Payment A is signed-in-flight: it cleared check() and reserved its cost but
+    // has not settled yet.
+    control.reserve(0.8);
+
+    // Payment B arrives concurrently. A's live $0.80 hold plus B's $0.80 is $1.60,
+    // over the $1.00/hr cap — B must be refused, or the two together overspend.
+    const result = control.check(0.8, {});
+    expect(result.allowed).toBe(false);
+    expect(result.blockedBy).toBe("hourly");
+  });
+
+  it("counts an in-flight reservation against the daily window while the clock advances mid-check", () => {
+    const control = new SpendControl({
+      storage: new InMemorySpendControlStorage(),
+      now: liveClock(),
+    });
+    control.setLimit("daily", 1.0);
+    control.reserve(0.8);
+
+    const result = control.check(0.8, {});
+    expect(result.allowed).toBe(false);
+    expect(result.blockedBy).toBe("daily");
+  });
+});
+
 describe("formatDuration", () => {
   it("formats seconds", () => {
     expect(formatDuration(30)).toBe("30s");

--- a/src/spend-control.ts
+++ b/src/spend-control.ts
@@ -461,7 +461,7 @@ export class SpendControl {
     }
 
     if (this.limits.hourly !== undefined) {
-      const hourlySpent = this.getSpendingInWindow(now - HOUR_MS, now);
+      const hourlySpent = this.getSpendingInWindow(now - HOUR_MS, now, now);
       const remaining = this.limits.hourly - hourlySpent;
       if (estimatedCost > remaining) {
         const oldestInWindow = this.history.find((r) => r.timestamp >= now - HOUR_MS);
@@ -479,7 +479,7 @@ export class SpendControl {
     }
 
     if (this.limits.daily !== undefined) {
-      const dailySpent = this.getSpendingInWindow(now - DAY_MS, now);
+      const dailySpent = this.getSpendingInWindow(now - DAY_MS, now, now);
       const remaining = this.limits.daily - dailySpent;
       if (estimatedCost > remaining) {
         const oldestInWindow = this.history.find((r) => r.timestamp >= now - DAY_MS);
@@ -600,23 +600,33 @@ export class SpendControl {
     }
   }
 
-  private getSpendingInWindow(from: number, to: number): number {
+  // `now` is the single clock reading the caller already took to build the
+  // window; it must be passed in, not re-read here. In-flight reservations are
+  // "now" holds, so they count only against a window that reaches the present
+  // (`to >= now`). The bug this guards against: reading the clock a SECOND time
+  // inside this method (the old `to >= this.now()`) could land a millisecond
+  // after the caller's `now`, flip the guard false, and silently drop the
+  // pending total from the hourly/daily check — letting two concurrent payments
+  // both clear the same remaining budget. Threading the caller's `now` keeps the
+  // guard meaningful (a genuinely historical window with `to < now` still
+  // excludes live holds) without a second, racing read. Every existing test
+  // injects a frozen clock (`now: () => clock`), so the two reads always matched
+  // and the sub-ms window went uncaught; see the live-clock test in
+  // spend-control.test.ts.
+  private getSpendingInWindow(from: number, to: number, now: number): number {
     const recorded = this.history
       .filter((r) => r.timestamp >= from && r.timestamp <= to)
       .reduce((sum, r) => sum + r.amount, 0);
-    // In-flight reservations count against every window they could land in.
-    // Both the hourly and daily windows end at `now`, so a live hold belongs
-    // to each of them.
-    return recorded + (to >= this.now() ? this.pendingTotal() : 0);
+    return recorded + (to >= now ? this.pendingTotal() : 0);
   }
 
   getSpending(window: "hourly" | "daily" | "session"): number {
     const now = this.now();
     switch (window) {
       case "hourly":
-        return this.getSpendingInWindow(now - HOUR_MS, now);
+        return this.getSpendingInWindow(now - HOUR_MS, now, now);
       case "daily":
-        return this.getSpendingInWindow(now - DAY_MS, now);
+        return this.getSpendingInWindow(now - DAY_MS, now, now);
       case "session":
         return this.sessionSpent + this.pendingTotal();
     }
@@ -630,8 +640,8 @@ export class SpendControl {
 
   getStatus(): SpendingStatus {
     const now = this.now();
-    const hourlySpent = this.getSpendingInWindow(now - HOUR_MS, now);
-    const dailySpent = this.getSpendingInWindow(now - DAY_MS, now);
+    const hourlySpent = this.getSpendingInWindow(now - HOUR_MS, now, now);
+    const dailySpent = this.getSpendingInWindow(now - DAY_MS, now, now);
 
     return {
       limits: cloneLimits(this.limits),


### PR DESCRIPTION
## What

`SpendControl.getSpendingInWindow()` decided whether in-flight reservations (`pendingTotal()`) count toward the hourly/daily spend by reading the clock a **second time**, and comparing it against the window bound the caller had already computed from a **first** read.

`check()` captures `now` once at its top and passes it as the window's `to`:

```ts
const now = this.now();                                        // read #1
const hourlySpent = this.getSpendingInWindow(now - HOUR_MS, now);
```
```ts
// inside getSpendingInWindow, before the fix:
return recorded + (to >= this.now() ? this.pendingTotal() : 0); // read #2
```

On the production clock (`() => Date.now()`), when a millisecond ticks between read #1 and read #2, `this.now() > to`, the guard goes **false**, and the in-flight reservation total is silently dropped from the hourly/daily figure.

### Why that's a money-path bug

Reservations are the concurrency-safety mechanism. The x402 pre-sign hook does check-then-`reserve()` synchronously, on purpose:

```ts
// Reserve synchronously — no await between check() and reserve() — so two
// concurrent payments cannot both clear the same remaining budget.
return control.reserve(estimatedCost);
```

When payment B's hourly/daily check drops payment A's live reservation, both clear the same remaining budget and **the operator's cap is exceeded**. The `session` window was unaffected — it reads `sessionSpent + pendingTotal()` directly, never through this guard — which is why the leak was narrow and silent.

Severity is bounded: the racing gap is sub-millisecond per check, so this is intermittent under concurrent paid load, not every request. No security impact — it's an accounting/limit-enforcement correctness bug in the payment path.

## Why the existing suite didn't catch it

Every test in `spend-control.test.ts` builds its `SpendControl` through a helper that injects a **frozen** clock:

```ts
let clock = nowMs;
const control = new SpendControl({ storage, now: () => clock });
```

With a frozen clock, read #1 and read #2 return the identical value, `to >= this.now()` is always true, the reservation is always counted, and the race cannot surface. The bug only appears when the clock actually advances between the two reads — which the frozen clock structurally prevents.

## Fix (threaded `now`)

Thread the caller's single clock reading into the helper and gate on it, instead of taking a second racing read:

```ts
private getSpendingInWindow(from: number, to: number, now: number): number {
  const recorded = /* history in [from, to] */;
  return recorded + (to >= now ? this.pendingTotal() : 0);
}
```

All six call sites (2 in `check()`, 2 in `getSpending()`, 2 in `getStatus()`) already had `now` in scope and now pass it through. This keeps the guard **meaningful** — a genuinely historical window (`to < now`) still correctly excludes live "now" holds — while removing the second, racing read. (I deliberately avoided the terser `to >= from`, which is always true for these callers and would leave the guard vacuous in a file reviewers scrutinize closely.)

## Tests (failing-first)

New `describe("in-flight reservations under a live (non-frozen) clock")` with an advancing clock (each read 1ms later), covering the hourly and daily windows. A comment on the block states explicitly why the frozen-clock suite missed this.

- Stashing only the source fix and keeping the new tests: **2 failed** on the pristine tree (`expected true to be false`).
- With the fix: **2 passed**; full `spend-control.test.ts` suite **71 passed** — every existing frozen-clock test unchanged and green.
- `tsc --noEmit`, `prettier --check`, `eslint`: clean.
- Full repo suite: `792 passed`. The 2 unrelated failures on the tree (`router/brand-numbers`, `router/free-model-liveness`) are pre-existing catalog/brand-snapshot drift — confirmed by reproducing them with this change stashed. **Zero new failures.**

## Scope

Touches only `src/spend-control.ts` and `src/spend-control.test.ts`. Independent of the unrelated `/stats?days` fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hourly and daily spending-limit checks to accurately account for pending reservations.
  - Prevented concurrent spending from bypassing limits when checks occur as time advances.
  - Updated spending totals and status information to remain consistent during in-flight transactions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->