### PR TITLE
fix(openclaw): stop injecting legacy auth-profiles.json beside SQLite stores

### DIFF
--- a/src/auth.injection.test.ts
+++ b/src/auth.injection.test.ts
@@ -30,8 +30,10 @@ describe("injectAuthProfile", () => {
     return { mod, homeDir };
   }
 
-  const agentDir = (home: string, agent: string) => join(home, ".openclaw", "agents", agent, "agent");
-  const authPath = (home: string, agent: string) => join(agentDir(home, agent), "auth-profiles.json");
+  const agentDir = (home: string, agent: string) =>
+    join(home, ".openclaw", "agents", agent, "agent");
+  const authPath = (home: string, agent: string) =>
+    join(agentDir(home, agent), "auth-profiles.json");
 
   it("still bootstraps the legacy JSON when no SQLite store exists", async () => {
     const { mod, homeDir } = await withHome();
@@ -99,7 +101,11 @@ describe("injectAuthProfile", () => {
       JSON.stringify({
         version: 1,
         profiles: {
-          "blockrun:default": { type: "api_key", provider: "blockrun", key: "x402-proxy-handles-auth" },
+          "blockrun:default": {
+            type: "api_key",
+            provider: "blockrun",
+            key: "x402-proxy-handles-auth",
+          },
           "anthropic:default": { type: "api_key", provider: "anthropic", key: "sk-real-key" },
         },
       }),

--- a/src/auth.injection.test.ts
+++ b/src/auth.injection.test.ts
@@ -1,0 +1,112 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The legacy auth-profiles.json write is now sqlite-aware: beside an
+// openclaw-agent.sqlite store the file is obsolete — and since OpenClaw
+// 2026.8.1 a leftover legacy file beside an empty store fails auth migration
+// closed, bricking dispatch for the whole agent fleet. These pin the new
+// behavior.
+describe("injectAuthProfile", () => {
+  let homeDir: string | undefined;
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("node:os");
+    if (homeDir) {
+      rmSync(homeDir, { recursive: true, force: true });
+      homeDir = undefined;
+    }
+  });
+
+  async function withHome() {
+    homeDir = mkdtempSync(join(tmpdir(), "clawrouter-auth-profile-"));
+    vi.doMock("node:os", async () => ({
+      ...(await vi.importActual<typeof import("node:os")>("node:os")),
+      homedir: () => homeDir,
+    }));
+    const mod = await import("./index.js");
+    return { mod, homeDir };
+  }
+
+  const agentDir = (home: string, agent: string) => join(home, ".openclaw", "agents", agent, "agent");
+  const authPath = (home: string, agent: string) => join(agentDir(home, agent), "auth-profiles.json");
+
+  it("still bootstraps the legacy JSON when no SQLite store exists", async () => {
+    const { mod, homeDir } = await withHome();
+    mkdirSync(agentDir(homeDir, "main"), { recursive: true });
+    mkdirSync(agentDir(homeDir, "mike"), { recursive: true });
+
+    mod.injectAuthProfile({ info: vi.fn() });
+
+    expect(existsSync(authPath(homeDir, "mike"))).toBe(true);
+    const store = JSON.parse(readFileSync(authPath(homeDir, "mike"), "utf8"));
+    expect(store.profiles["blockrun:default"]?.key).toBe("x402-proxy-handles-auth");
+  });
+
+  it("never writes into the shared auth-owner directory, even without a store", async () => {
+    const { mod, homeDir } = await withHome();
+    mkdirSync(agentDir(homeDir, "main"), { recursive: true });
+
+    mod.injectAuthProfile({ info: vi.fn() });
+
+    expect(existsSync(authPath(homeDir, "main"))).toBe(false);
+  });
+
+  it("does not write the legacy JSON beside an existing SQLite store", async () => {
+    const { mod, homeDir } = await withHome();
+    const dir = agentDir(homeDir, "mike");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "openclaw-agent.sqlite"), "placeholder bytes");
+
+    mod.injectAuthProfile({ info: vi.fn() });
+
+    expect(existsSync(authPath(homeDir, "mike"))).toBe(false);
+  });
+
+  it("removes our own placeholder beside a SQLite store", async () => {
+    const { mod, homeDir } = await withHome();
+    const dir = agentDir(homeDir, "mike");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "openclaw-agent.sqlite"), "placeholder bytes");
+    writeFileSync(
+      authPath(homeDir, "mike"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "blockrun:default": {
+            type: "api_key",
+            provider: "blockrun",
+            key: "x402-proxy-handles-auth",
+          },
+        },
+      }),
+    );
+
+    mod.injectAuthProfile({ info: vi.fn() });
+
+    expect(existsSync(authPath(homeDir, "mike"))).toBe(false);
+  });
+
+  it("never removes a JSON file that carries real credentials", async () => {
+    const { mod, homeDir } = await withHome();
+    const dir = agentDir(homeDir, "mike");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "openclaw-agent.sqlite"), "placeholder bytes");
+    writeFileSync(
+      authPath(homeDir, "mike"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "blockrun:default": { type: "api_key", provider: "blockrun", key: "x402-proxy-handles-auth" },
+          "anthropic:default": { type: "api_key", provider: "anthropic", key: "sk-real-key" },
+        },
+      }),
+    );
+
+    mod.injectAuthProfile({ info: vi.fn() });
+
+    expect(existsSync(authPath(homeDir, "mike"))).toBe(true);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ import {
   mkdirSync,
   copyFileSync,
   renameSync,
+  unlinkSync,
 } from "node:fs";
 import { readFile as readFileAsync } from "node:fs/promises";
 import { readTextFileSync } from "./fs-read.js";
@@ -617,8 +618,21 @@ function syncAgentModelCache(
 
 /**
  * Inject dummy auth profile for BlockRun into agent auth stores.
- * OpenClaw's agent system looks for auth credentials even if provider has auth: [].
- * We inject a placeholder so the lookup succeeds (proxy handles real auth internally).
+ *
+ * The legacy ``auth-profiles.json`` write is now deliberately narrow:
+ *
+ * - Wherever ``openclaw-agent.sqlite`` exists, the SQLite auth store is
+ *   authoritative. Writing the legacy JSON beside it is at best ignored, at
+ *   worst a failed-closed migration trigger: since OpenClaw 2026.8.1 a
+ *   leftover legacy file beside a store that holds no profiles fails auth
+ *   migration for the whole agent fleet. So we never write there, and we
+ *   clean up the placeholder we previously injected.
+ * - The shared auth-owner directory (``main``) is managed by OpenClaw
+ *   itself; a placeholder written there can shadow that state. The
+ *   provider's real auth comes from the x402 proxy (and the apiKey
+ *   injectModelsConfig writes into openclaw.json), so nothing is lost.
+ * - Only on very old installs with no SQLite store at all do we keep the
+ *   original JSON bootstrap, which those releases import.
  */
 function injectAuthProfile(logger: { info: (msg: string) => void }): void {
   const agentsDir = join(homedir(), ".openclaw", "agents");
@@ -649,6 +663,22 @@ function injectAuthProfile(logger: { info: (msg: string) => void }): void {
     for (const agentId of agents) {
       const authDir = join(agentsDir, agentId, "agent");
       const authPath = join(authDir, "auth-profiles.json");
+      const sqlitePath = join(authDir, "openclaw-agent.sqlite");
+
+      // SQLite store exists: it is authoritative, and the legacy JSON is
+      // obsolete. Remove our own placeholder and never rewrite it.
+      if (existsSync(sqlitePath)) {
+        removeInjectedAuthPlaceholder(authPath, logger, agentId);
+        continue;
+      }
+
+      // Never write into the shared auth-owner directory. OpenClaw manages
+      // its credentials centrally, and a leftover legacy file there is what
+      // fails dispatch closed on 2026.8.1+ when that store is empty.
+      if (agentId === "main") {
+        removeInjectedAuthPlaceholder(authPath, logger, agentId);
+        continue;
+      }
 
       // Create agent dir if needed
       if (!existsSync(authDir)) {
@@ -703,6 +733,42 @@ function injectAuthProfile(logger: { info: (msg: string) => void }): void {
     }
   } catch (err) {
     logger.info(`Auth injection failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/**
+ * Remove a legacy ``auth-profiles.json`` — but only when it contains nothing
+ * but the exact placeholder this plugin injects. A real user credential file
+ * is never touched.
+ */
+function removeInjectedAuthPlaceholder(
+  authPath: string,
+  logger: { info: (msg: string) => void },
+  agentId: string,
+): void {
+  try {
+    if (!existsSync(authPath)) return;
+    const parsed = JSON.parse(readTextFileSync(authPath)) as {
+      profiles?: Record<string, unknown>;
+    };
+    const profiles = parsed?.profiles;
+    if (!profiles || typeof profiles !== "object" || Array.isArray(profiles)) return;
+    const keys = Object.keys(profiles);
+    if (keys.length !== 1 || keys[0] !== "blockrun:default") return;
+    const entry = profiles["blockrun:default"];
+    if (!entry || typeof entry !== "object") return;
+    const profile = entry as { type?: unknown; provider?: unknown; key?: unknown };
+    if (
+      profile.type !== "api_key" ||
+      profile.provider !== "blockrun" ||
+      profile.key !== "x402-proxy-handles-auth"
+    ) {
+      return;
+    }
+    unlinkSync(authPath);
+    logger.info(`Removed legacy BlockRun auth placeholder for agent: ${agentId}`);
+  } catch {
+    // Unreadable or not our file — leave it alone.
   }
 }
 


### PR DESCRIPTION
## Summary
`injectAuthProfile()` writes a placeholder `agent/auth-profiles.json` into every agent directory — including the shared auth-owner (`main`). On OpenClaw 2026.8.1 the SQLite auth store is authoritative, and a leftover legacy JSON beside an **empty** store (main's store is legitimately empty after `doctor --fix` relocates shared credentials) fails auth migration closed, which bricks message dispatch for the whole agent fleet.

This PR makes the write SQLite-aware:
- If `openclaw-agent.sqlite` exists, the legacy JSON is never written, and the plugin removes its own previously-injected placeholder (only the exact `blockrun:default` placeholder — real credential files are never touched).
- The shared auth-owner directory (`main`) is never written into at all.
- Only installs with no SQLite store at all keep the old JSON bootstrap.

The provider's real auth comes from the x402 proxy and the `apiKey` that `injectModelsConfig` writes into `openclaw.json`, so nothing is lost.

## Reproduction & verification (OpenClaw 2026.8.1)
Reproduced with the unfixed 0.12.259 build on a host upgraded to 2026.8.1:
```
[agents/prepared-model-runtime] auth-triggered model runtime refresh failed:
AuthProfileMigrationRequiredError: Auth profile store ~/.openclaw/agents/main/agent/openclaw-agent.sqlite
requires legacy credential migration
```
`openclaw doctor --lint --all` showed error findings on `core/doctor/auth-profiles` and `core/doctor/runtime-tool-schemas`, plus gateway-health secret degradation.

With this fix on the same host:
- The plugin logs `Removed legacy BlockRun auth placeholder for agent: main` and the file stays gone across restarts.
- `openclaw doctor --lint --all`: zero auth-related findings, no `AuthProfileMigrationRequiredError`, no prepared-model-runtime failures.
- Gateway and proxy healthy (HTTP 200), no dispatch errors.

Also verified on OpenClaw 2026.7.1-2: stops the repeated `auth-profiles.json.sqlite-import.*.bak` re-import churn with no regression.

## Tests
- New `src/auth.injection.test.ts` (5 tests): legacy bootstrap kept when no store exists, `main` never written, no write beside an existing store, placeholder removed beside a store, real credential files never removed.
- Full suite: 792 passed + 5 new; `npm run typecheck`, `npm run lint`, `npm run format:check` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented legacy authentication placeholder files from being created in shared or SQLite-backed agent directories.
  * Automatically removes previously created placeholder files when a SQLite store is present.
  * Preserves authentication files containing real credentials.
* **Tests**
  * Added coverage for placeholder creation, removal, and credential-preservation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->