### PR TITLE
fix(polymarket): reject non-positive amount_usd in trade/withdraw

### DIFF
--- a/src/polymarket/orders.ts
+++ b/src/polymarket/orders.ts
@@ -289,6 +289,23 @@ export async function executeTrade(input: TradeInput): Promise<ToolResult> {
       isError: true,
     };
   }
+  // A non-positive amount_usd would otherwise become the order's notional
+  // (see below) and, being additive, a negative value lets the ledger check
+  // (`ledger.totalUsd + notional > sessionCap`) be satisfied by *reducing*
+  // totalUsd instead of raising it — silently defeating POLYMARKET_MAX_SESSION_USD
+  // for every order placed afterward. Reject before any network call, same as
+  // fund.ts's amount_usd guard.
+  if (
+    !isLimit &&
+    input.action === "buy" &&
+    input.amount_usd !== undefined &&
+    input.amount_usd <= 0
+  ) {
+    return {
+      text: `amount_usd must be a positive dollar amount to spend, got ${input.amount_usd}.`,
+      isError: true,
+    };
+  }
   if (!isLimit && input.action === "sell" && input.size === undefined) {
     return { text: `Market sells need size (shares to sell).`, isError: true };
   }

--- a/src/polymarket/polymarket.test.ts
+++ b/src/polymarket/polymarket.test.ts
@@ -112,4 +112,21 @@ describe("trade gating (cross-field validation, no network)", () => {
     expect(r.isError).toBe(true);
     expect(r.text).toMatch(/GTD orders need expires_at/i);
   });
+
+  // A negative or zero amount_usd must be rejected here, before any network
+  // call: it becomes the order's notional, and being additive it lets
+  // `ledger.totalUsd + notional > sessionCap` be satisfied by *reducing*
+  // totalUsd instead of raising it — silently defeating
+  // POLYMARKET_MAX_SESSION_USD for every order placed afterward.
+  it("rejects a market buy with a negative amount_usd before touching the CLOB", async () => {
+    const r = await executeTrade({ action: "buy", token_id: "1", amount_usd: -5 });
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/amount_usd must be a positive dollar amount/i);
+  });
+
+  it("rejects a market buy with amount_usd of zero before touching the CLOB", async () => {
+    const r = await executeTrade({ action: "buy", token_id: "1", amount_usd: 0 });
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/amount_usd must be a positive dollar amount/i);
+  });
 });

--- a/src/polymarket/withdraw.test.ts
+++ b/src/polymarket/withdraw.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { withdrawFunds } from "./withdraw.js";
+
+describe("withdraw gating (input validation, no network)", () => {
+  // A non-positive amount_usd would otherwise reach the balance check
+  // (amountRaw > balanceRaw is false for zero or negative amounts) and the
+  // bridge/transfer call downstream. Reject before any network call, same as
+  // fund.ts's amount_usd guard.
+  it("rejects a negative amount_usd before touching the network", async () => {
+    const r = await withdrawFunds({ amount_usd: -5 });
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/amount_usd must be a positive dollar amount/i);
+  });
+
+  it("rejects amount_usd of zero before touching the network", async () => {
+    const r = await withdrawFunds({ amount_usd: 0 });
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/amount_usd must be a positive dollar amount/i);
+  });
+});

--- a/src/polymarket/withdraw.ts
+++ b/src/polymarket/withdraw.ts
@@ -48,6 +48,16 @@ interface WithdrawInput {
 }
 
 export async function withdrawFunds(input: WithdrawInput): Promise<ToolResult> {
+  // A non-positive amount_usd would otherwise pass the balance check below
+  // (amountRaw > balanceRaw is false for zero or negative amounts) and reach
+  // the bridge/transfer call. Reject before any network call, same as
+  // fund.ts's amount_usd guard.
+  if (input.amount_usd !== undefined && input.amount_usd <= 0) {
+    return {
+      text: `amount_usd must be a positive dollar amount, got ${input.amount_usd}. Omit it to withdraw the full balance.`,
+      isError: true,
+    };
+  }
   let owner: Hex;
   try {
     owner = getFundsAddress();


### PR DESCRIPTION
Fixes an input-validation gap in `executeTrade()` (market buy path) and `withdrawFunds()`: neither rejected a non-positive `amount_usd`, unlike the sibling `fund.ts`.

- `orders.ts`: a negative `amount_usd` becomes a negative order notional. `reserveBet()` does `ledger.totalUsd += notional`, so a negative notional *decreases* the running total instead of increasing it — letting `ledger.totalUsd + notional > sessionCap` stay satisfied indefinitely and silently defeating `POLYMARKET_MAX_SESSION_USD` for every subsequent order.
- `withdraw.ts`: `amountRaw > balanceRaw` is false for zero/negative amounts, so a non-positive `amount_usd` passes the balance check and reaches the bridge transfer call.

Both are fixed with the same guard pattern already used in `fund.ts`. Added two new tests to `polymarket.test.ts` (market-buy path) and a new `withdraw.test.ts` (withdraw path); verified failing before the fix, passing after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Trades and withdrawals are now checked against configured spending policies before authorization.
  - Rejected trades release their reserved session balance.

- **Bug Fixes**
  - Purchases and withdrawals reject invalid, non-finite, zero, or negative dollar amounts before processing.
  - Limit orders reject invalid or non-positive sizes before network requests.
  - Invalid requests no longer trigger network calls.

- **Tests**
  - Added coverage for invalid purchase amounts, limit-order sizes, and withdrawal amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->