### PR TITLE
fix(ci): format CHANGELOG.md so Lint & Typecheck goes green again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to ClawRouter.
 `SpendControl.getSpendingInWindow()` decided whether in-flight reservations counted toward the hourly/daily spend by reading the clock a **second** time and comparing it against a window bound the caller had already built from a **first** read:
 
 ```ts
-const now = this.now();                                        // read #1
+const now = this.now(); // read #1
 const hourlySpent = this.getSpendingInWindow(now - HOUR_MS, now);
 // ...inside:
 return recorded + (to >= this.now() ? this.pendingTotal() : 0); // read #2


### PR DESCRIPTION
One line. `prettier --check .` has failed on `main` since the v0.12.263 release commit (`fa0b146`) at 04:54 today, because that commit's fenced code block used aligned trailing comments:

```diff
-const now = this.now();                                        // read #1
+const now = this.now(); // read #1
```

Every PR branched from that commit inherits the red `Lint & Typecheck`, including #294, whose own diff is clean. This unblocks them.

My miss: I ran `prettier --check` on the two source files edited in that release but not on the CHANGELOG written in the same commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted an inline changelog comment for improved consistency.
  * No functional or user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->