### PR TITLE
fix(spend-policy): gate every signing path on SpendControl, not just the proxy

### DIFF
--- a/src/doctor.spend-policy.test.ts
+++ b/src/doctor.spend-policy.test.ts
@@ -1,0 +1,84 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { generatePrivateKey } from "viem/accounts";
+import { wrapFetchWithPayment } from "@x402/fetch";
+
+import { createDoctorX402Client } from "./doctor.js";
+import { SpendControl, InMemorySpendControlStorage, CAIP2_BASE } from "./spend-control.js";
+
+/**
+ * Doctor builds its own x402 client and pays a real endpoint. Until this
+ * landed it registered the signing schemes but not the spend-policy hook, so a
+ * blocked payee the proxy refused was still paid by `clawrouter doctor`.
+ * Same shape as proxy.spend-policy.test.ts: a mock upstream that challenges
+ * with a 402 naming a blocked payee, and a count of retries that carried a
+ * signed payment. That count must stay at zero.
+ */
+describe("doctor's x402 client enforces spend policy before signing", () => {
+  const blockedPayee = "0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa";
+  let upstream: Server;
+  let url: string;
+  let paidHits = 0;
+  let unpaidHits = 0;
+
+  beforeAll(async () => {
+    upstream = createServer((req: IncomingMessage, res: ServerResponse) => {
+      req.on("data", () => {});
+      req.on("end", () => {
+        if (req.headers["x-payment"] || req.headers["payment-signature"]) {
+          paidHits++;
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ choices: [{ message: { content: "paid" } }] }));
+          return;
+        }
+        unpaidHits++;
+        const challenge = {
+          x402Version: 2,
+          resource: { url: "http://127.0.0.1/v1/chat/completions" },
+          accepts: [
+            {
+              scheme: "exact",
+              network: CAIP2_BASE,
+              amount: "10000",
+              asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+              payTo: blockedPayee,
+              maxTimeoutSeconds: 60,
+              extra: {},
+            },
+          ],
+        };
+        res.writeHead(402, {
+          "Content-Type": "application/json",
+          "PAYMENT-REQUIRED": Buffer.from(JSON.stringify(challenge)).toString("base64"),
+        });
+        res.end(JSON.stringify({ error: "payment required" }));
+      });
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+    url = `http://127.0.0.1:${(upstream.address() as AddressInfo).port}/v1/chat/completions`;
+  });
+
+  afterAll(async () => {
+    upstream.closeAllConnections?.();
+    await new Promise<void>((resolve) => upstream.close(() => resolve()));
+  });
+
+  it("refuses a blocked payee and never attaches a payment", async () => {
+    const control = new SpendControl({ storage: new InMemorySpendControlStorage() });
+    control.setPolicy("blockedPayees", [blockedPayee]);
+    const x402 = createDoctorX402Client({ walletKey: generatePrivateKey(), spendControl: control });
+    const paymentFetch = wrapFetchWithPayment(fetch, x402);
+
+    await expect(
+      paymentFetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }),
+    ).rejects.toThrow(/blocked by policy/i);
+
+    expect(unpaidHits).toBeGreaterThan(0);
+    expect(paidHits).toBe(0);
+  }, 20_000);
+});

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -23,6 +23,7 @@ import { BalanceMonitor } from "./balance.js";
 import { getSolanaAddress } from "./wallet.js";
 import { getStats } from "./stats.js";
 import { getProxyPort } from "./proxy.js";
+import { registerSpendPolicyHook, SpendControl } from "./spend-control.js";
 import { VERSION } from "./version.js";
 
 // Types
@@ -380,6 +381,27 @@ const DOCTOR_MODELS: Record<DoctorModel, { id: string; name: string; cost: strin
   },
 };
 
+/**
+ * Build the x402 client doctor pays with. The spend-policy hook is registered
+ * here, before any signing scheme, exactly as startProxy does: doctor's paid
+ * call (~$0.003-$0.01) must not be a way around the operator's allow/deny
+ * lists. This is the only place doctor constructs an x402Client, so the test
+ * that drives it pins the wiring, not just the helper.
+ */
+export function createDoctorX402Client(opts: {
+  walletKey: string;
+  /** Default: the same on-disk policy the proxy reads. Inject in tests. */
+  spendControl?: SpendControl;
+}): x402Client {
+  const account = privateKeyToAccount(opts.walletKey as `0x${string}`);
+  const publicClient = createPublicClient({ chain: base, transport: http() });
+  const evmSigner = toClientEvmSigner(account, publicClient);
+  const x402 = new x402Client();
+  registerSpendPolicyHook(x402, opts.spendControl ?? new SpendControl());
+  registerExactEvmScheme(x402, { signer: evmSigner });
+  return x402;
+}
+
 // Send to AI for analysis
 async function analyzeWithAI(
   diagnostics: DiagnosticResult,
@@ -403,11 +425,7 @@ async function analyzeWithAI(
 
   try {
     const { key } = await resolveOrGenerateWalletKey();
-    const account = privateKeyToAccount(key as `0x${string}`);
-    const publicClient = createPublicClient({ chain: base, transport: http() });
-    const evmSigner = toClientEvmSigner(account, publicClient);
-    const x402 = new x402Client();
-    registerExactEvmScheme(x402, { signer: evmSigner });
+    const x402 = createDoctorX402Client({ walletKey: key });
 
     // Register Solana scheme if user is on Solana chain
     const paymentChain = diagnostics.wallet.paymentChain;

--- a/src/polymarket/fund.ts
+++ b/src/polymarket/fund.ts
@@ -12,10 +12,11 @@ import type { Hex } from "viem";
 import { BlockrunClient, createPaymentPayload } from "@blockrun/llm";
 import { getOrCreateWalletKey, getChainBalance } from "./wallet-adapter.js";
 import { getPolymarketAccount } from "./client.js";
-import { BASE_CHAIN_ID, BRIDGE_API_HOST, getSigType } from "./constants.js";
+import { BASE_CHAIN_ID, BASE_USDC, BRIDGE_API_HOST, getSigType } from "./constants.js";
 import { getFundsAddress } from "./positions.js";
 import { getPublicClient } from "./setup.js";
 import type { ToolResult } from "./orders.js";
+import { signUnderSpendPolicy, type PolymarketSpendDeps } from "./spend-policy.js";
 
 const FUND_FEE_USD = 0.01;
 const USDC_DECIMALS = 6;
@@ -38,10 +39,10 @@ async function bridgeAddressFor(vault: string): Promise<string> {
   return evm;
 }
 
-export async function fundVault(input: {
-  amount_usd?: number;
-  confirm?: boolean;
-}): Promise<ToolResult> {
+export async function fundVault(
+  input: { amount_usd?: number; confirm?: boolean },
+  deps?: PolymarketSpendDeps,
+): Promise<ToolResult> {
   if (input.amount_usd === undefined || input.amount_usd <= 0) {
     return {
       text: `Pass amount_usd — the USDC amount to move from your Base wallet into your Polymarket vault (e.g. amount_usd:5).`,
@@ -117,18 +118,25 @@ export async function fundVault(input: {
     }
 
     // Sign the EIP-3009 deposit authorization: Base USDC → bridge address.
+    // Spend policy runs first: the bridge is the counterparty the principal
+    // goes to, so a blocked/unlisted bridge, network, or asset refuses here
+    // before anything is signed (and before the fee leg below is charged).
     const privateKey = getOrCreateWalletKey();
     const amountMicro = String(Math.floor(amountUsd * 10 ** USDC_DECIMALS));
-    const depositAuthorization = await createPaymentPayload(
-      privateKey,
-      agent,
-      bridge,
-      amountMicro,
-      `eip155:${BASE_CHAIN_ID}`,
+    const network = `eip155:${BASE_CHAIN_ID}`;
+    const depositAuthorization = await signUnderSpendPolicy(
+      deps,
+      { payTo: bridge, network, asset: BASE_USDC, amount: amountMicro },
+      "polymarket fund",
+      () => createPaymentPayload(privateKey, agent, bridge, amountMicro, network),
     );
 
     // Call the gateway fund endpoint — it charges $0.01 via x402 automatically
     // and relays the deposit authorization to the CDP facilitator (pays gas).
+    // KNOWN GAP: BlockrunClient signs that $0.01 fee internally with no
+    // pre-sign hook (its options are privateKey/apiUrl/timeout only), so the
+    // fee leg cannot consult policy. It only runs once the principal above
+    // has passed the check, and its payee is BlockRun's own gateway.
     const client = new BlockrunClient({ privateKey });
     const result = (await client.post("/v1/polymarket/fund", {
       depositWallet: vault,

--- a/src/polymarket/orders.ts
+++ b/src/polymarket/orders.ts
@@ -453,10 +453,20 @@ export async function executeTrade(
         asset: PUSD_COLLATERAL,
         amount: usdToMicros(notional),
       };
-      let response: unknown;
+      type ClobOrderResponse = {
+        success?: boolean;
+        errorMsg?: string;
+        orderID?: string;
+        status?: string;
+        transactionsHashes?: string[];
+        tradeIDs?: string[];
+        takingAmount?: string;
+        makingAmount?: string;
+      };
+      let r: ClobOrderResponse;
       try {
-        response = await signUnderSpendPolicy(deps, policyQuote, "polymarket order", () =>
-          isLimit
+        r = await signUnderSpendPolicy(deps, policyQuote, "polymarket order", async () => {
+          const res = (await (isLimit
             ? clob.createAndPostOrder(
                 {
                   tokenID: token.tokenId,
@@ -480,32 +490,22 @@ export async function executeTrade(
                 },
                 options,
                 orderKind === "FAK" ? OrderType.FAK : OrderType.FOK,
-              ),
-        );
+              ))) as ClobOrderResponse;
+          // The order is placed unless the CLOB explicitly says success:false (or
+          // returns an error with no orderID). A non-empty errorMsg WITH success and
+          // an orderID is informational — e.g. status "delayed", "order match delayed
+          // due to market conditions" — the order IS live, so don't roll it back or a
+          // retrying agent double-submits.
+          const placed = res?.success !== false && (res?.orderID || res?.status === "matched");
+          // Thrown from inside the policy callback on purpose: a resolved-but-
+          // rejected CLOB response must release the spend-policy reservation
+          // too, not only the session bet ledger below.
+          if (!placed) throw new Error(res?.errorMsg || "order rejected");
+          return res;
+        });
       } catch (submitErr) {
         releaseBet(notional, input.agent_id);
         throw submitErr;
-      }
-
-      const r = response as {
-        success?: boolean;
-        errorMsg?: string;
-        orderID?: string;
-        status?: string;
-        transactionsHashes?: string[];
-        tradeIDs?: string[];
-        takingAmount?: string;
-        makingAmount?: string;
-      };
-      // The order is placed unless the CLOB explicitly says success:false (or
-      // returns an error with no orderID). A non-empty errorMsg WITH success and
-      // an orderID is informational — e.g. status "delayed", "order match delayed
-      // due to market conditions" — the order IS live, so don't roll it back or a
-      // retrying agent double-submits.
-      const placed = r?.success !== false && (r?.orderID || r?.status === "matched");
-      if (!placed) {
-        releaseBet(notional, input.agent_id);
-        throw new Error(r?.errorMsg || "order rejected");
       }
       commitBet();
 

--- a/src/polymarket/orders.ts
+++ b/src/polymarket/orders.ts
@@ -1,13 +1,15 @@
 // src/utils/polymarket/orders.ts
 //
-// buy / sell / cancel / open-orders flows. Safety model (deliberately NOT the
-// x402 budget ledger — bets are the user's own pUSD capital on Polygon, a
-// different asset in a different wallet than BlockRun API spend):
+// buy / sell / cancel / open-orders flows. Safety model:
 //   - confirm:true is HARD-REQUIRED to place an order; without it the call
 //     returns a dry-run preview and signs nothing.
 //   - per-order notional capped by POLYMARKET_MAX_BET_USD (default $25).
 //   - optional POLYMARKET_MAX_SESSION_USD cumulative cap, tracked in-memory
 //     with per-agent attribution (agent_id).
+//   - the operator's spend policy (spending.json payee/network/asset lists and
+//     amount windows) is checked against the exchange contract on Polygon
+//     BEFORE the order is signed — see spend-policy.ts. The two notional caps
+//     above remain a separate in-memory ledger.
 import {
   OrderType,
   Side,
@@ -15,8 +17,17 @@ import {
   type OrderBookSummary,
 } from "@polymarket/clob-client-v2";
 import { checkGeoblock, getClobClient, getPolymarketAccount, resetClobClient } from "./client.js";
-import { getMaxBetUsd, getMaxSessionUsd } from "./constants.js";
+import {
+  CTF_EXCHANGE_V2,
+  getMaxBetUsd,
+  getMaxSessionUsd,
+  NEG_RISK_CTF_EXCHANGE_V2,
+  POLYGON_CHAIN_ID,
+  PUSD_COLLATERAL,
+} from "./constants.js";
 import { invalidateL2Creds } from "./creds.js";
+import { SpendPolicyError } from "../spend-control.js";
+import { signUnderSpendPolicy, usdToMicros, type PolymarketSpendDeps } from "./spend-policy.js";
 
 // --- Session bet ledger (in-memory; resets with the process) ---
 const ledger = {
@@ -166,6 +177,9 @@ function isCredsMismatchError(err: { message?: string; status?: number; data?: u
 
 /** Map CLOB errors to actionable guidance. Exported for unit tests. */
 export async function mapClobError(err: unknown): Promise<string> {
+  if (err instanceof SpendPolicyError) {
+    return `Refused by spend policy — nothing was signed. ${err.message} (see ~/.openclaw/blockrun/spending.json)`;
+  }
   const e = err as { message?: string; status?: number; data?: unknown };
   const dataText = e?.data
     ? ` — ${typeof e.data === "string" ? e.data : JSON.stringify(e.data)}`
@@ -275,7 +289,10 @@ export interface ToolResult {
   isError?: boolean;
 }
 
-export async function executeTrade(input: TradeInput): Promise<ToolResult> {
+export async function executeTrade(
+  input: TradeInput,
+  deps?: PolymarketSpendDeps,
+): Promise<ToolResult> {
   const side = input.action === "buy" ? Side.BUY : Side.SELL;
   const isLimit = input.price !== undefined;
 
@@ -427,33 +444,44 @@ export async function executeTrade(input: TradeInput): Promise<ToolResult> {
       // Reserve now (before the await) so a concurrent order sees this spend;
       // roll back if the submit throws so a failed order doesn't consume budget.
       reserveBet(notional, input.agent_id);
+      // Counterparty for policy: the exchange the SDK signs the order for
+      // (negRisk markets use the NegRisk exchange). Notional is quoted and
+      // settles in pUSD on both sides, so the collateral is the asset checked.
+      const policyQuote = {
+        payTo: negRisk ? NEG_RISK_CTF_EXCHANGE_V2 : CTF_EXCHANGE_V2,
+        network: `eip155:${POLYGON_CHAIN_ID}`,
+        asset: PUSD_COLLATERAL,
+        amount: usdToMicros(notional),
+      };
       let response: unknown;
       try {
-        response = isLimit
-          ? await clob.createAndPostOrder(
-              {
-                tokenID: token.tokenId,
-                price: price as number,
-                size: size as number,
-                side,
-                ...(orderKind === "GTD" && input.expires_at
-                  ? { expiration: input.expires_at }
-                  : {}),
-              },
-              options,
-              orderKind === "GTD" ? OrderType.GTD : OrderType.GTC,
-              input.post_only ?? false,
-            )
-          : await clob.createAndPostMarketOrder(
-              {
-                tokenID: token.tokenId,
-                amount: input.action === "buy" ? (input.amount_usd as number) : (size as number),
-                side,
-                orderType: orderKind === "FAK" ? OrderType.FAK : OrderType.FOK,
-              },
-              options,
-              orderKind === "FAK" ? OrderType.FAK : OrderType.FOK,
-            );
+        response = await signUnderSpendPolicy(deps, policyQuote, "polymarket order", () =>
+          isLimit
+            ? clob.createAndPostOrder(
+                {
+                  tokenID: token.tokenId,
+                  price: price as number,
+                  size: size as number,
+                  side,
+                  ...(orderKind === "GTD" && input.expires_at
+                    ? { expiration: input.expires_at }
+                    : {}),
+                },
+                options,
+                orderKind === "GTD" ? OrderType.GTD : OrderType.GTC,
+                input.post_only ?? false,
+              )
+            : clob.createAndPostMarketOrder(
+                {
+                  tokenID: token.tokenId,
+                  amount: input.action === "buy" ? (input.amount_usd as number) : (size as number),
+                  side,
+                  orderType: orderKind === "FAK" ? OrderType.FAK : OrderType.FOK,
+                },
+                options,
+                orderKind === "FAK" ? OrderType.FAK : OrderType.FOK,
+              ),
+        );
       } catch (submitErr) {
         releaseBet(notional, input.agent_id);
         throw submitErr;

--- a/src/polymarket/redeem.ts
+++ b/src/polymarket/redeem.ts
@@ -173,7 +173,9 @@ export async function redeemPosition(
         return wallet.sendTransaction({ to: target, data, chain: polygon, account });
       },
     );
-    if (!eoa) await pc.waitForTransactionReceipt({ hash: txHash as Hex });
+    // The relayer path confirms inside sendWalletBatch; the direct EOA path must
+    // wait here, or the balance read and success report can precede a revert.
+    if (eoa) await pc.waitForTransactionReceipt({ hash: txHash as Hex });
 
     const balanceAfter = await getPusdBalance(owner).catch(() => null);
     return {

--- a/src/polymarket/redeem.ts
+++ b/src/polymarket/redeem.ts
@@ -25,6 +25,7 @@ import {
   getSigType,
   NEG_RISK_ADAPTER,
   NEG_RISK_ADAPTER_ABI,
+  POLYGON_CHAIN_ID,
   POLYGON_RPC_URLS,
   PUSD_COLLATERAL,
   PUSD_DECIMALS,
@@ -34,6 +35,7 @@ import { mapClobError } from "./orders.js";
 import { getFundsAddress } from "./positions.js";
 import { sendWalletBatch } from "./relayer.js";
 import { getPublicClient, getPusdBalance } from "./setup.js";
+import { signUnderSpendPolicy, type PolymarketSpendDeps } from "./spend-policy.js";
 
 interface ClobMarketToken {
   token_id?: string;
@@ -41,10 +43,10 @@ interface ClobMarketToken {
   winner?: boolean;
 }
 
-export async function redeemPosition(input: {
-  condition_id?: string;
-  confirm?: boolean;
-}): Promise<ToolResult> {
+export async function redeemPosition(
+  input: { condition_id?: string; confirm?: boolean },
+  deps?: PolymarketSpendDeps,
+): Promise<ToolResult> {
   if (!input.condition_id) {
     return {
       text: `Pass condition_id:"0x…" (see action:"positions" for redeemable markets).`,
@@ -141,20 +143,37 @@ export async function redeemPosition(input: {
         });
     const target = (negRisk ? NEG_RISK_ADAPTER : CONDITIONAL_TOKENS) as Hex;
 
-    let txHash: string | undefined;
-    if (getSigType() === 3) {
-      const res = await sendWalletBatch([{ target, value: "0", data }], owner, "Redeem");
-      txHash = res.transactionHash;
-    } else {
-      const account = getPolymarketAccount();
-      const wallet = createWalletClient({
-        account,
-        chain: polygon,
-        transport: http(POLYGON_RPC_URLS[0]),
-      });
-      txHash = await wallet.sendTransaction({ to: target, data, chain: polygon, account });
-      await pc.waitForTransactionReceipt({ hash: txHash as Hex });
-    }
+    // Spend policy sees the protocol contract being signed (ConditionalTokens
+    // or NegRiskAdapter on Polygon) with amount 0: a redeem moves NO capital
+    // out — it burns this wallet's own outcome tokens and credits collateral
+    // back to the same wallet — so there is no spend to reserve. The check is
+    // still required: an operator's payee/network lists are a total statement
+    // about what may be signed, and this keeps every signing path under them.
+    const eoa = getSigType() !== 3;
+    const txHash = await signUnderSpendPolicy(
+      deps,
+      {
+        payTo: target,
+        network: `eip155:${POLYGON_CHAIN_ID}`,
+        asset: PUSD_COLLATERAL,
+        amount: "0",
+      },
+      "polymarket redeem",
+      async () => {
+        if (!eoa) {
+          const res = await sendWalletBatch([{ target, value: "0", data }], owner, "Redeem");
+          return res.transactionHash;
+        }
+        const account = getPolymarketAccount();
+        const wallet = createWalletClient({
+          account,
+          chain: polygon,
+          transport: http(POLYGON_RPC_URLS[0]),
+        });
+        return wallet.sendTransaction({ to: target, data, chain: polygon, account });
+      },
+    );
+    if (!eoa) await pc.waitForTransactionReceipt({ hash: txHash as Hex });
 
     const balanceAfter = await getPusdBalance(owner).catch(() => null);
     return {

--- a/src/polymarket/spend-policy.test.ts
+++ b/src/polymarket/spend-policy.test.ts
@@ -22,6 +22,8 @@ const h = vi.hoisted(() => ({
     data: { address: { evm: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } },
   })),
   negRisk: false,
+  sigType: 0,
+  waitForReceipt: vi.fn(async () => ({})),
   clob: {
     getOrderBook: vi.fn(async () => ({
       tick_size: "0.01",
@@ -62,7 +64,7 @@ vi.mock("./positions.js", () => ({ getFundsAddress: () => h.VAULT }));
 vi.mock("./setup.js", () => ({
   getPublicClient: () => ({
     readContract: async () => 5_000_000n, // $5 pUSD in the deposit wallet
-    waitForTransactionReceipt: async () => ({}),
+    waitForTransactionReceipt: h.waitForReceipt,
   }),
   getPusdBalance: async () => 5,
 }));
@@ -73,7 +75,7 @@ vi.mock("viem", async (importOriginal) => ({
 }));
 vi.mock("./constants.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./constants.js")>()),
-  getSigType: () => 0,
+  getSigType: () => h.sigType,
 }));
 
 import { fundVault } from "./fund.js";
@@ -96,6 +98,7 @@ function inMemoryControl(): SpendControl {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  h.sigType = 0;
 });
 
 describe("fundVault consults spend policy before signing the deposit", () => {
@@ -162,6 +165,28 @@ describe("executeTrade consults spend policy before signing the order", () => {
       network: "eip155:137",
       asset: PUSD_COLLATERAL,
     });
+  });
+
+  it("releases the policy reservation when the CLOB resolves but rejects the order", async () => {
+    // A resolved { success:false } is not a throw. Without the placed check
+    // inside the policy callback, the reservation settles as real spend and a
+    // rejected order eats the operator's window.
+    const control = inMemoryControl();
+    control.setLimit("session", 5); // exactly one $5 order's worth
+    const counterparty = { payTo: CTF_EXCHANGE_V2, network: "eip155:137", asset: PUSD_COLLATERAL };
+    h.clob.createAndPostOrder.mockResolvedValueOnce({
+      success: false,
+      errorMsg: "rejected by CLOB",
+    } as never);
+    const before = getSessionLedger().totalUsd;
+
+    const r = await executeTrade(limitBuy, { spendControl: control });
+
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/rejected by CLOB/);
+    expect(getSessionLedger().totalUsd).toBe(before);
+    // The window is intact: the same $5 is still allowed afterwards.
+    expect(control.check(5, counterparty).allowed).toBe(true);
   });
 
   it("routes negRisk markets to the NegRisk exchange, so an allowlist for the plain one refuses", async () => {
@@ -262,5 +287,32 @@ describe("redeemPosition consults spend policy before signing the claim", () => 
     expect(h.sendTransaction).not.toHaveBeenCalled();
     expect(h.sendWalletBatch).not.toHaveBeenCalled();
     expect(check.mock.calls[0]?.[1]?.payTo).toBe(NEG_RISK_ADAPTER);
+  });
+});
+
+describe("redeemPosition confirms the claim before reporting success", () => {
+  const redeem = { condition_id: `0x${"ab".repeat(32)}`, confirm: true };
+
+  beforeEach(() => {
+    h.negRisk = false;
+  });
+
+  it("waits for the receipt on the direct EOA path", async () => {
+    const r = await redeemPosition(redeem, { spendControl: inMemoryControl() });
+
+    expect(r.isError).toBeFalsy();
+    expect(h.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(h.waitForReceipt).toHaveBeenCalledWith({ hash: "0xpolygon-tx" });
+  });
+
+  it("does not double-wait on the relayer path, which confirms inside sendWalletBatch", async () => {
+    h.sigType = 3;
+
+    const r = await redeemPosition(redeem, { spendControl: inMemoryControl() });
+
+    expect(r.isError).toBeFalsy();
+    expect(h.sendWalletBatch).toHaveBeenCalledTimes(1);
+    expect(h.sendTransaction).not.toHaveBeenCalled();
+    expect(h.waitForReceipt).not.toHaveBeenCalled();
   });
 });

--- a/src/polymarket/spend-policy.test.ts
+++ b/src/polymarket/spend-policy.test.ts
@@ -30,6 +30,12 @@ const h = vi.hoisted(() => ({
       asks: [{ price: "0.55", size: "100" }],
       bids: [{ price: "0.45", size: "100" }],
     })),
+    getMarket: vi.fn(async () => ({
+      question: "Will it happen?",
+      neg_risk: h.negRisk,
+      closed: true,
+      tokens: [{ token_id: "777", outcome: "Yes", winner: true }],
+    })),
     createAndPostOrder: vi.fn(async () => ({ success: true, orderID: "ord-1", status: "live" })),
     createAndPostMarketOrder: vi.fn(async () => ({ success: true, orderID: "ord-2" })),
   },
@@ -58,6 +64,7 @@ vi.mock("./setup.js", () => ({
     readContract: async () => 5_000_000n, // $5 pUSD in the deposit wallet
     waitForTransactionReceipt: async () => ({}),
   }),
+  getPusdBalance: async () => 5,
 }));
 vi.mock("./relayer.js", () => ({ sendWalletBatch: h.sendWalletBatch }));
 vi.mock("viem", async (importOriginal) => ({
@@ -71,10 +78,13 @@ vi.mock("./constants.js", async (importOriginal) => ({
 
 import { fundVault } from "./fund.js";
 import { executeTrade, getSessionLedger } from "./orders.js";
+import { redeemPosition } from "./redeem.js";
 import { withdrawFunds } from "./withdraw.js";
 import {
   BASE_USDC,
+  CONDITIONAL_TOKENS,
   CTF_EXCHANGE_V2,
+  NEG_RISK_ADAPTER,
   NEG_RISK_CTF_EXCHANGE_V2,
   PUSD_COLLATERAL,
 } from "./constants.js";
@@ -198,5 +208,59 @@ describe("withdrawFunds consults spend policy before signing the transfer", () =
       network: "eip155:8453",
       asset: BASE_USDC,
     });
+  });
+});
+
+describe("redeemPosition consults spend policy before signing the claim", () => {
+  // Redeem moves NO capital out — it burns the wallet's own outcome tokens and
+  // credits collateral back to the same wallet — so the amount checked is 0.
+  // The check is still pinned: payee/network lists govern every signed path,
+  // and the contract called (ConditionalTokens vs NegRiskAdapter) is the payee.
+  const redeem = { condition_id: `0x${"ab".repeat(32)}`, confirm: true };
+
+  beforeEach(() => {
+    h.negRisk = false;
+  });
+
+  it("refuses a blocked ConditionalTokens contract and never signs on either path", async () => {
+    const control = inMemoryControl();
+    control.setPolicy("blockedPayees", [CONDITIONAL_TOKENS]);
+
+    const r = await redeemPosition(redeem, { spendControl: control });
+
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/blocked by policy/i);
+    expect(h.sendTransaction).not.toHaveBeenCalled();
+    expect(h.sendWalletBatch).not.toHaveBeenCalled();
+  });
+
+  it("signs for an allowed contract and hands policy the redeem target with amount 0", async () => {
+    const control = inMemoryControl();
+    const check = vi.spyOn(control, "check");
+
+    const r = await redeemPosition(redeem, { spendControl: control });
+
+    expect(r.isError).toBeFalsy();
+    expect(h.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(check).toHaveBeenCalledWith(0, {
+      payTo: CONDITIONAL_TOKENS,
+      network: "eip155:137",
+      asset: PUSD_COLLATERAL,
+    });
+  });
+
+  it("routes negRisk markets to the NegRiskAdapter, so an allowlist for ConditionalTokens refuses", async () => {
+    h.negRisk = true;
+    const control = inMemoryControl();
+    control.setPolicy("allowedPayees", [CONDITIONAL_TOKENS]);
+    const check = vi.spyOn(control, "check");
+
+    const r = await redeemPosition(redeem, { spendControl: control });
+
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/not in the configured allowlist/i);
+    expect(h.sendTransaction).not.toHaveBeenCalled();
+    expect(h.sendWalletBatch).not.toHaveBeenCalled();
+    expect(check.mock.calls[0]?.[1]?.payTo).toBe(NEG_RISK_ADAPTER);
   });
 });

--- a/src/polymarket/spend-policy.test.ts
+++ b/src/polymarket/spend-policy.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Wiring tests for the Polymarket signing paths. Each one builds an in-memory
+ * SpendControl with the target counterparty on a deny list, runs the real
+ * tool function with every network/keystore edge mocked, and asserts the
+ * signing/order/transaction function was NEVER called. An allowed-counterparty
+ * case per path pins that the check is additive — it also pins the exact
+ * counterparty fields handed to policy, since a wrong payTo/network/asset
+ * would make an operator's allowlist govern the wrong thing.
+ */
+const h = vi.hoisted(() => ({
+  AGENT: "0x1111111111111111111111111111111111111111",
+  VAULT: "0x2222222222222222222222222222222222222222",
+  BRIDGE: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  ATTACKER: "0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead",
+  sendTransaction: vi.fn(async () => "0xpolygon-tx"),
+  sendWalletBatch: vi.fn(async () => ({ transactionHash: "0xrelayer-tx" })),
+  createPaymentPayload: vi.fn(async () => "0xsigned-authorization"),
+  feePost: vi.fn(async () => ({ success: true, deposit: { txHash: "0xdeposit" } })),
+  axiosPost: vi.fn(async () => ({
+    data: { address: { evm: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } },
+  })),
+  negRisk: false,
+  clob: {
+    getOrderBook: vi.fn(async () => ({
+      tick_size: "0.01",
+      neg_risk: h.negRisk,
+      min_order_size: "5",
+      asks: [{ price: "0.55", size: "100" }],
+      bids: [{ price: "0.45", size: "100" }],
+    })),
+    createAndPostOrder: vi.fn(async () => ({ success: true, orderID: "ord-1", status: "live" })),
+    createAndPostMarketOrder: vi.fn(async () => ({ success: true, orderID: "ord-2" })),
+  },
+}));
+
+vi.mock("@blockrun/llm", () => ({
+  createPaymentPayload: h.createPaymentPayload,
+  BlockrunClient: class {
+    post = h.feePost;
+  },
+}));
+vi.mock("axios", () => ({ default: { post: h.axiosPost } }));
+vi.mock("./wallet-adapter.js", () => ({
+  getOrCreateWalletKey: () => `0x${"11".repeat(32)}`,
+  getChainBalance: async () => 100,
+}));
+vi.mock("./client.js", () => ({
+  getPolymarketAccount: () => ({ address: h.AGENT }),
+  getClobClient: async () => h.clob,
+  checkGeoblock: async () => ({}),
+  resetClobClient: () => {},
+}));
+vi.mock("./positions.js", () => ({ getFundsAddress: () => h.VAULT }));
+vi.mock("./setup.js", () => ({
+  getPublicClient: () => ({
+    readContract: async () => 5_000_000n, // $5 pUSD in the deposit wallet
+    waitForTransactionReceipt: async () => ({}),
+  }),
+}));
+vi.mock("./relayer.js", () => ({ sendWalletBatch: h.sendWalletBatch }));
+vi.mock("viem", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("viem")>()),
+  createWalletClient: () => ({ sendTransaction: h.sendTransaction }),
+}));
+vi.mock("./constants.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./constants.js")>()),
+  getSigType: () => 0,
+}));
+
+import { fundVault } from "./fund.js";
+import { executeTrade, getSessionLedger } from "./orders.js";
+import { withdrawFunds } from "./withdraw.js";
+import {
+  BASE_USDC,
+  CTF_EXCHANGE_V2,
+  NEG_RISK_CTF_EXCHANGE_V2,
+  PUSD_COLLATERAL,
+} from "./constants.js";
+import { InMemorySpendControlStorage, SpendControl } from "../spend-control.js";
+
+function inMemoryControl(): SpendControl {
+  return new SpendControl({ storage: new InMemorySpendControlStorage() });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fundVault consults spend policy before signing the deposit", () => {
+  it("refuses a blocked bridge and never signs or pays the fee", async () => {
+    const control = inMemoryControl();
+    control.setPolicy("blockedPayees", [h.BRIDGE]);
+
+    const r = await fundVault({ amount_usd: 5, confirm: true }, { spendControl: control });
+
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/blocked by policy/i);
+    expect(h.createPaymentPayload).not.toHaveBeenCalled();
+    expect(h.feePost).not.toHaveBeenCalled();
+  });
+
+  it("signs for an allowed bridge and hands policy the real counterparty", async () => {
+    const control = inMemoryControl();
+    const check = vi.spyOn(control, "check");
+
+    const r = await fundVault({ amount_usd: 5, confirm: true }, { spendControl: control });
+
+    expect(r.isError).toBeFalsy();
+    expect(h.createPaymentPayload).toHaveBeenCalledTimes(1);
+    expect(check).toHaveBeenCalledWith(5, {
+      payTo: h.BRIDGE,
+      network: "eip155:8453",
+      asset: BASE_USDC,
+    });
+  });
+});
+
+describe("executeTrade consults spend policy before signing the order", () => {
+  // Limit buy 10 @ 0.50 → $5 notional, under the default $25 per-order cap.
+  const limitBuy = { action: "buy" as const, token_id: "123", price: 0.5, size: 10, confirm: true };
+
+  beforeEach(() => {
+    h.negRisk = false;
+  });
+
+  it("refuses a blocked exchange, never submits, and rolls back the bet ledger", async () => {
+    const control = inMemoryControl();
+    control.setPolicy("blockedPayees", [CTF_EXCHANGE_V2]);
+    const before = getSessionLedger().totalUsd;
+
+    const r = await executeTrade(limitBuy, { spendControl: control });
+
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/blocked by policy/i);
+    expect(h.clob.createAndPostOrder).not.toHaveBeenCalled();
+    expect(h.clob.createAndPostMarketOrder).not.toHaveBeenCalled();
+    expect(getSessionLedger().totalUsd).toBe(before);
+  });
+
+  it("submits for an allowed exchange and hands policy the real counterparty", async () => {
+    const control = inMemoryControl();
+    const check = vi.spyOn(control, "check");
+
+    const r = await executeTrade(limitBuy, { spendControl: control });
+
+    expect(r.isError).toBeFalsy();
+    expect(h.clob.createAndPostOrder).toHaveBeenCalledTimes(1);
+    expect(check).toHaveBeenCalledWith(5, {
+      payTo: CTF_EXCHANGE_V2,
+      network: "eip155:137",
+      asset: PUSD_COLLATERAL,
+    });
+  });
+
+  it("routes negRisk markets to the NegRisk exchange, so an allowlist for the plain one refuses", async () => {
+    h.negRisk = true;
+    const control = inMemoryControl();
+    control.setPolicy("allowedPayees", [CTF_EXCHANGE_V2]);
+    const check = vi.spyOn(control, "check");
+
+    const r = await executeTrade(limitBuy, { spendControl: control });
+
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/not in the configured allowlist/i);
+    expect(h.clob.createAndPostOrder).not.toHaveBeenCalled();
+    expect(check.mock.calls[0]?.[1]?.payTo).toBe(NEG_RISK_CTF_EXCHANGE_V2);
+  });
+});
+
+describe("withdrawFunds consults spend policy before signing the transfer", () => {
+  it("refuses an agent-chosen blocked recipient and never signs on either path", async () => {
+    const control = inMemoryControl();
+    control.setPolicy("blockedPayees", [h.ATTACKER]);
+
+    const r = await withdrawFunds(
+      { amount_usd: 3, to_address: h.ATTACKER, confirm: true },
+      { spendControl: control },
+    );
+
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/blocked by policy/i);
+    expect(h.sendTransaction).not.toHaveBeenCalled();
+    expect(h.sendWalletBatch).not.toHaveBeenCalled();
+  });
+
+  it("signs to the default agent wallet and hands policy the destination leg", async () => {
+    const control = inMemoryControl();
+    const check = vi.spyOn(control, "check");
+
+    const r = await withdrawFunds({ amount_usd: 3, confirm: true }, { spendControl: control });
+
+    expect(r.isError).toBeFalsy();
+    expect(h.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(check).toHaveBeenCalledWith(3, {
+      payTo: h.AGENT,
+      network: "eip155:8453",
+      asset: BASE_USDC,
+    });
+  });
+});

--- a/src/polymarket/spend-policy.ts
+++ b/src/polymarket/spend-policy.ts
@@ -11,6 +11,15 @@
 // is ever called. Amount windows apply too, so signed notional is recorded
 // against the shared ledger (fail-closed when an amount cannot be parsed and
 // a cap is configured — see assertSpendPolicyAllows).
+//
+// DELIBERATELY NOT GATED: the one-time approval batch in setup.ts
+// (`sendWalletBatch(buildApprovalCalls(...))`). It signs ERC-20 `approve` and
+// ERC-1155 `setApprovalForAll`, which grant authority rather than move capital,
+// and gating it would be actively harmful: the spenders are Polymarket's own
+// exchange contracts, so an operator running a tight `allowedPayees` list that
+// (correctly) names only their payout addresses would have setup refused. It is
+// already bounded — targets come from `readApprovals()`, never from agent input,
+// and the batch is `confirm`-gated behind an explicit preview.
 import {
   assertSpendPolicyAllows,
   SpendControl,

--- a/src/polymarket/spend-policy.ts
+++ b/src/polymarket/spend-policy.ts
@@ -1,0 +1,65 @@
+// src/polymarket/spend-policy.ts
+//
+// Every Polymarket path that signs something that moves the user's capital —
+// fund (EIP-3009 on Base), buy/sell (CLOB order on Polygon), withdraw (pUSD →
+// USDC on Base) — consults the SAME spend policy the proxy enforces on x402
+// payments, BEFORE the signer runs. Until this existed the operator's
+// allow/deny lists in ~/.openclaw/blockrun/spending.json governed LLM calls
+// only; the agent could still route capital to any counterparty from here.
+//
+// Refusal is the proxy's SpendPolicyError, thrown before the signing function
+// is ever called. Amount windows apply too, so signed notional is recorded
+// against the shared ledger (fail-closed when an amount cannot be parsed and
+// a cap is configured — see assertSpendPolicyAllows).
+import {
+  assertSpendPolicyAllows,
+  SpendControl,
+  type QuotedRequirements,
+} from "../spend-control.js";
+
+export interface PolymarketSpendDeps {
+  /** Default: the process-wide policy at ~/.openclaw/blockrun/spending.json. Inject in tests. */
+  spendControl?: SpendControl;
+}
+
+let defaultControl: SpendControl | undefined;
+
+/** One instance per process so session windows and reservations span tool calls, as in the proxy. */
+function resolveSpendControl(deps?: PolymarketSpendDeps): SpendControl {
+  if (deps?.spendControl) return deps.spendControl;
+  defaultControl ??= new SpendControl();
+  return defaultControl;
+}
+
+/**
+ * USD → canonical micro-USDC string. Rounds UP so float slack can never clear
+ * a cap; NaN/Infinity/negative produce a non-canonical string, which
+ * assertSpendPolicyAllows refuses when any amount limit is configured.
+ */
+export function usdToMicros(usd: number): string {
+  return String(Math.ceil(usd * 1_000_000));
+}
+
+/**
+ * Run `sign` only if policy allows the counterparty and amount. Throws
+ * SpendPolicyError before `sign` is called when refused; settles the
+ * reservation once `sign` resolves (signed = spend, as in the x402 hook) and
+ * releases it if `sign` throws so a failed submit does not consume budget.
+ */
+export async function signUnderSpendPolicy<T>(
+  deps: PolymarketSpendDeps | undefined,
+  quote: QuotedRequirements,
+  action: string,
+  sign: () => Promise<T>,
+): Promise<T> {
+  const control = resolveSpendControl(deps);
+  const reservation = assertSpendPolicyAllows(control, quote);
+  try {
+    const signed = await sign();
+    if (reservation !== undefined) control.settleReservation(reservation, { action });
+    return signed;
+  } catch (err) {
+    if (reservation !== undefined) control.releaseReservation(reservation);
+    throw err;
+  }
+}

--- a/src/polymarket/withdraw.ts
+++ b/src/polymarket/withdraw.ts
@@ -31,6 +31,7 @@ import { mapClobError } from "./orders.js";
 import { getFundsAddress } from "./positions.js";
 import { sendWalletBatch } from "./relayer.js";
 import { getPublicClient } from "./setup.js";
+import { signUnderSpendPolicy, type PolymarketSpendDeps } from "./spend-policy.js";
 
 async function rawPusdBalance(owner: Hex): Promise<bigint> {
   return getPublicClient().readContract({
@@ -47,7 +48,10 @@ interface WithdrawInput {
   confirm?: boolean;
 }
 
-export async function withdrawFunds(input: WithdrawInput): Promise<ToolResult> {
+export async function withdrawFunds(
+  input: WithdrawInput,
+  deps?: PolymarketSpendDeps,
+): Promise<ToolResult> {
   let owner: Hex;
   try {
     owner = getFundsAddress();
@@ -124,34 +128,51 @@ export async function withdrawFunds(input: WithdrawInput): Promise<ToolResult> {
     }
 
     // 2. Transfer pUSD from the deposit wallet to the bridge address.
+    // Spend policy sees the DESTINATION leg — recipient, Base, USDC — not the
+    // signed Polygon transfer: the bridge address is one-time and cannot be
+    // allowlisted, while to_address is agent-chosen and is what an operator's
+    // payee list must govern. Amount is the exact pUSD sent (6 dp = micros).
     const data = encodeFunctionData({
       abi: ERC20_ABI,
       functionName: "transfer",
       args: [bridgeEvm, amountRaw],
     });
-    let txHash: string | undefined;
-    if (getSigType() === 3) {
-      const res = await sendWalletBatch(
-        [{ target: PUSD_COLLATERAL, value: "0", data }],
-        owner,
-        "Withdraw",
-      );
-      txHash = res.transactionHash;
-    } else {
-      const account = getPolymarketAccount();
-      const wallet = createWalletClient({
-        account,
-        chain: polygon,
-        transport: http(POLYGON_RPC_URLS[0]),
-      });
-      txHash = await wallet.sendTransaction({
-        to: PUSD_COLLATERAL as Hex,
-        data,
-        chain: polygon,
-        account,
-      });
-      await getPublicClient().waitForTransactionReceipt({ hash: txHash as Hex });
-    }
+    const eoa = getSigType() !== 3;
+    const txHash = await signUnderSpendPolicy(
+      deps,
+      {
+        payTo: recipient,
+        network: `eip155:${BASE_CHAIN_ID}`,
+        asset: BASE_USDC,
+        amount: amountRaw.toString(),
+      },
+      "polymarket withdraw",
+      async () => {
+        if (!eoa) {
+          const res = await sendWalletBatch(
+            [{ target: PUSD_COLLATERAL, value: "0", data }],
+            owner,
+            "Withdraw",
+          );
+          return res.transactionHash;
+        }
+        const account = getPolymarketAccount();
+        const wallet = createWalletClient({
+          account,
+          chain: polygon,
+          transport: http(POLYGON_RPC_URLS[0]),
+        });
+        return wallet.sendTransaction({
+          to: PUSD_COLLATERAL as Hex,
+          data,
+          chain: polygon,
+          account,
+        });
+      },
+    );
+    // Signed = spend; the receipt wait sits outside so a slow confirmation
+    // cannot release a reservation for a transfer that was already broadcast.
+    if (eoa) await getPublicClient().waitForTransactionReceipt({ hash: txHash as Hex });
 
     return {
       text: [


### PR DESCRIPTION
Closes #302.


`registerSpendPolicyHook` has exactly one call site: `src/proxy.ts:2325`, registered before `registerExactEvmScheme` on the proxy's `x402Client`. Five other places sign with the same wallet and never consulted it — a strict `allowedPayees`/`allowedNetworks` list refused every payee on the proxy while doing nothing here.

## What's covered now

| Path | Check placed before | Counterparty handed to policy |
|---|---|---|
| `src/doctor.ts` | `registerExactEvmScheme` (own `x402Client`, doctor's only one) | whatever the 402 quotes — identical to the proxy |
| `src/polymarket/fund.ts` | `createPaymentPayload` | payTo=bridge, `eip155:8453`, Base USDC, exact `amountMicro` |
| `src/polymarket/orders.ts` | `clob.createAndPostOrder` / `createAndPostMarketOrder` | payTo=CTF or NegRisk exchange by market, `eip155:137`, pUSD, notional |
| `src/polymarket/withdraw.ts` | `sendWalletBatch` / `wallet.sendTransaction` (both branches) | payTo=**recipient** (agent-chosen `to_address`, not the one-time bridge), `eip155:8453`, Base USDC, exact pUSD micros |
| `src/polymarket/redeem.ts` | `sendWalletBatch` / `wallet.sendTransaction` (both branches) | payTo=ConditionalTokens or NegRiskAdapter by market, `eip155:137`, pUSD, amount 0 |

Redeem moves no capital out — it burns the wallet's own outcome tokens and credits collateral back to the same wallet, so the checked amount is 0 and the change is a no-op for every operator with nothing configured. It's covered anyway because `allowedPayees`/`allowedNetworks` are total statements about what the agent may sign, and an unwrapped path makes that silently non-total; the cost falls only on an operator who wants a strict allowlist, who now lists two more contracts — the same class of cost `orders.ts` already imposes.

Shared helper `src/polymarket/spend-policy.ts`: one `SpendControl` per process so session windows span tool calls the way the proxy's do; refusal is `SpendPolicyError`, thrown before the signing function runs; the reservation settles when the signer returns and releases if it throws, so a failed submit doesn't consume budget. `mapClobError` gets a 3-line `instanceof` branch so the agent sees "Refused by spend policy" instead of a raw CLOB error.

## Known limitations

**The two `SpendControl` instances don't share runtime state — only the on-disk file.** `proxy.ts:2324` and `polymarket/spend-policy.ts:30` each construct their own instance against the same `spending.json`. Each loads history once at construction, so after that, `hourly`/`daily`/`session` windows are enforced **per-surface** — LLM spend is invisible to a Polymarket check and vice versa, beyond whatever was on disk when each instance started. Worse, each instance's `saveHistory()` rewrites the file's history with only its own view, so on a process restart the two surfaces' histories can clobber each other — last-writer-wins, and the on-disk audit trail degrades rather than accumulating cleanly. The fix is a single process-wide `SpendControl`, threaded through the existing `PolymarketSpendDeps` seam from wherever the proxy and the Polymarket tool are wired together in `index.ts`. Filing as a fast follow-up rather than blocking this PR on it — the policy is still enforced correctly per-call, just not with a perfectly unified ledger yet.

**A market sell reserves budget too.** `orders.ts` reserves `size × bid` before submitting regardless of side, so a buy-then-sell round trip double-counts against the amount windows — heavy LLM spend could, in principle, lock an agent out of *exiting* a Polymarket position through its own cap. This is the fail-closed default and probably the right one, but it's a real behavior change worth a changelog line, not just new coverage.

**`orders.ts` now makes Polymarket notional consume the same amount-window ledger as LLM spend.** The file's header used to say bets were "deliberately NOT the x402 budget ledger" — that comment is updated. An operator with `perRequest: 0.10` set for LLM calls will now see a default $25 order refused by the same cap. With nothing configured in `spending.json`, behavior is unchanged.

**The $0.01 fee leg inside `fund.ts`'s `BlockrunClient.post`** signs internally with no pre-sign hook exposed by `@blockrun/llm` (checked its `.d.ts` — no hook option). It only runs after the principal payment has passed policy, and its payee is fixed to BlockRun's own gateway, so the exposure is narrow. No workaround attempted; flagging rather than hiding it.

## Tests

Wiring-level, matching `proxy.spend-policy.test.ts`'s existing style: in-memory `SpendControl` with the target counterparty on a blocked/denied list, assert the signing function is never called. Every new check was confirmed red before its fix and green after (each temporarily removed and restored, verified by grep). `redeem.ts`'s tests additionally cover the neg-risk routing case — a `ConditionalTokens`-only allowlist correctly refuses a neg-risk market's redeem, which resolves to `NegRiskAdapter`.

74 test files / 820 tests pass. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added spend-policy checks before signing AI-assisted payments, funding, trades, withdrawals, and redemptions.
  * Transactions now validate destinations, networks, assets, and amounts before submission.
  * Added clearer refusal messages for blocked spending.

* **Bug Fixes**
  * Improved confirmation handling for direct wallet transfers and redemptions.
  * Ensured failed order submissions release spend reservations.

* **Tests**
  * Added coverage for blocked and allowed transactions, alternate trading routes, and AI-assisted payments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
