### PR TITLE
fix(proxy): invoke onPayment after confirmed settlement

### DIFF
--- a/src/payment-preauth.test.ts
+++ b/src/payment-preauth.test.ts
@@ -84,7 +84,10 @@ function fakeGateway() {
         ctl.rejectNextPaid = false;
         return challenge402(); // underpayment rejected
       }
-      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "payment-response": "settled" },
+      });
     }
     return challenge402();
   });
@@ -97,6 +100,57 @@ function body(maxTokens = 10) {
 }
 
 describe("payment pre-auth — per-request pricing safety", () => {
+  it("notifies once after the normal 402 then accepted paid retry", async () => {
+    const gw = fakeGateway();
+    const onPayment = vi.fn();
+    const pay = createPayFetchWithPreAuth(gw.fn, testClient(), undefined, {
+      estimateAmount: () => "1000",
+      onPayment,
+    });
+
+    await pay(URL, { method: "POST", body: body() });
+
+    expect(onPayment).toHaveBeenCalledOnce();
+    expect(onPayment).toHaveBeenCalledWith({
+      model: "test/model",
+      amount: "1000",
+      network: "eip155:8453",
+    });
+  });
+
+  it("notifies once for an accepted cached pre-auth and never for a rejected one", async () => {
+    const gw = fakeGateway();
+    const onPayment = vi.fn();
+    const pay = createPayFetchWithPreAuth(gw.fn, testClient(), undefined, {
+      estimateAmount: () => "1000",
+      onPayment,
+    });
+
+    await pay(URL, { method: "POST", body: body() });
+    onPayment.mockClear();
+    await pay(URL, { method: "POST", body: body() });
+    expect(onPayment).toHaveBeenCalledOnce();
+
+    onPayment.mockClear();
+    gw.ctl.rejectNextPaid = true;
+    await pay(URL, { method: "POST", body: body() });
+    expect(onPayment).toHaveBeenCalledOnce();
+  });
+
+  it("does not let an observer failure turn a settled response into a retry", async () => {
+    const gw = fakeGateway();
+    const pay = createPayFetchWithPreAuth(gw.fn, testClient(), undefined, {
+      estimateAmount: () => "1000",
+      onPayment: () => {
+        throw new Error("observer failed");
+      },
+    });
+
+    const res = await pay(URL, { method: "POST", body: body() });
+    expect(res.status).toBe(200);
+    expect(gw.calls.map((call) => call.paid)).toEqual([false, true]);
+  });
+
   it("reuses pre-auth when the estimate proves the cache still covers it (no extra 402)", async () => {
     const est = vi.fn(() => "1000"); // every request estimated equal
     const gw = fakeGateway();

--- a/src/payment-preauth.ts
+++ b/src/payment-preauth.ts
@@ -47,11 +47,17 @@ const DEFAULT_TTL_MS = 3_600_000; // 1 hour
 
 type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
+export type PaymentNotification = { model: string; amount: string; network: string };
+
 export function createPayFetchWithPreAuth(
   baseFetch: FetchFn,
   client: x402Client,
   ttlMs = DEFAULT_TTL_MS,
-  options?: { skipPreAuth?: boolean; estimateAmount?: EstimateFn },
+  options?: {
+    skipPreAuth?: boolean;
+    estimateAmount?: EstimateFn;
+    onPayment?: (info: PaymentNotification) => void;
+  },
 ): FetchFn {
   const httpClient = new x402HTTPClient(client);
   const cache = new Map<string, CachedEntry>();
@@ -91,6 +97,28 @@ export function createPayFetchWithPreAuth(
       }
     }
     const cacheKey = `${urlPath}:${requestModel}`;
+
+    const notifyAcceptedPayment = (
+      response: Response,
+      payload: { accepted: { amount: string; network: string } },
+    ): void => {
+      const settled =
+        response.headers.has("payment-response") || response.headers.has("x-payment-response");
+      if (!settled || !options?.onPayment) return;
+      try {
+        options.onPayment({
+          model: requestModel,
+          amount: payload.accepted.amount,
+          network: payload.accepted.network,
+        });
+      } catch (error) {
+        // The observer runs after settlement. Its failure must not turn a paid
+        // response into a retryable request and risk a second charge.
+        console.error(
+          `[ClawRouter] onPayment callback failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    };
 
     // Up-front estimate of what THIS request will cost (USDC micro-units), used
     // both to gate pre-auth reuse and to record what a new cache entry covers.
@@ -132,6 +160,7 @@ export function createPayFetchWithPreAuth(
         paymentInFlight = true;
         const response = await baseFetch(preAuthRequest);
         if (response.status !== 402) {
+          notifyAcceptedPayment(response, payload);
           return response; // Pre-auth worked — saved ~200ms
         }
         // Rejected despite our estimate (server priced it higher than we did).
@@ -200,6 +229,8 @@ export function createPayFetchWithPreAuth(
     for (const [key, value] of Object.entries(paymentHeaders)) {
       clonedRequest.headers.set(key, value);
     }
-    return baseFetch(clonedRequest);
+    const paidResponse = await baseFetch(clonedRequest);
+    notifyAcceptedPayment(paidResponse, payload);
+    return paidResponse;
   };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2414,6 +2414,7 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
     // payment still covers the (possibly larger) request — BlockRun prices per
     // token, so one model can cost different amounts across requests.
     estimateAmount,
+    onPayment: options.onPayment,
   });
 
   // Create balance monitor for pre-request checks (lazy import to avoid loading @solana/kit on Base chain)


### PR DESCRIPTION
Closes #321.

`ProxyOptions.onPayment` is public and documented, but the custom pre-auth fetch path never invoked it. Put the notification at the layer that owns both paid paths:

- normal 402 -> signed retry
- cached pre-auth -> paid first request

It fires only when the paid response carries the v2 `PAYMENT-RESPONSE` or v1 `X-PAYMENT-RESPONSE` settlement header. A rejected 402 does not fire it. Observer exceptions are contained after settlement so they cannot turn a paid response into a retry and risk a second charge.

Coverage proves normal and cached paths notify exactly once, a rejected cached payment does not add a notification, and a throwing observer does not trigger a retry.

Validation: 935 tests passed, 1 skipped; typecheck, ESLint, Prettier, and diff check pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payment notifications for settled payments, including the payment model, amount, and network.
  * Payment notifications now work for both pre-authorized payments and standard payment retries.
  * Proxy payment observers are now notified when payments are completed.

* **Bug Fixes**
  * Observer errors no longer cause successful payments to be retried.
  * Prevented duplicate notifications when cached pre-authorizations are rejected and refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->