### PR TITLE
fix(proxy): invoke onPayment after confirmed settlement (rebase of #325)

### DIFF
--- a/src/payment-preauth.test.ts
+++ b/src/payment-preauth.test.ts
@@ -84,7 +84,10 @@ function fakeGateway() {
         ctl.rejectNextPaid = false;
         return challenge402(); // underpayment rejected
       }
-      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "payment-response": "settled" },
+      });
     }
     return challenge402();
   });
@@ -97,6 +100,57 @@ function body(maxTokens = 10) {
 }
 
 describe("payment pre-auth — per-request pricing safety", () => {
+  it("notifies once after the normal 402 then accepted paid retry", async () => {
+    const gw = fakeGateway();
+    const onPayment = vi.fn();
+    const pay = createPayFetchWithPreAuth(gw.fn, testClient(), undefined, {
+      estimateAmount: () => "1000",
+      onPayment,
+    });
+
+    await pay(URL, { method: "POST", body: body() });
+
+    expect(onPayment).toHaveBeenCalledOnce();
+    expect(onPayment).toHaveBeenCalledWith({
+      model: "test/model",
+      amount: "1000",
+      network: "eip155:8453",
+    });
+  });
+
+  it("notifies once for an accepted cached pre-auth and never for a rejected one", async () => {
+    const gw = fakeGateway();
+    const onPayment = vi.fn();
+    const pay = createPayFetchWithPreAuth(gw.fn, testClient(), undefined, {
+      estimateAmount: () => "1000",
+      onPayment,
+    });
+
+    await pay(URL, { method: "POST", body: body() });
+    onPayment.mockClear();
+    await pay(URL, { method: "POST", body: body() });
+    expect(onPayment).toHaveBeenCalledOnce();
+
+    onPayment.mockClear();
+    gw.ctl.rejectNextPaid = true;
+    await pay(URL, { method: "POST", body: body() });
+    expect(onPayment).toHaveBeenCalledOnce();
+  });
+
+  it("does not let an observer failure turn a settled response into a retry", async () => {
+    const gw = fakeGateway();
+    const pay = createPayFetchWithPreAuth(gw.fn, testClient(), undefined, {
+      estimateAmount: () => "1000",
+      onPayment: () => {
+        throw new Error("observer failed");
+      },
+    });
+
+    const res = await pay(URL, { method: "POST", body: body() });
+    expect(res.status).toBe(200);
+    expect(gw.calls.map((call) => call.paid)).toEqual([false, true]);
+  });
+
   it("reuses pre-auth when the estimate proves the cache still covers it (no extra 402)", async () => {
     const est = vi.fn(() => "1000"); // every request estimated equal
     const gw = fakeGateway();

--- a/src/payment-preauth.ts
+++ b/src/payment-preauth.ts
@@ -47,11 +47,17 @@ const DEFAULT_TTL_MS = 3_600_000; // 1 hour
 
 type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
+export type PaymentNotification = { model: string; amount: string; network: string };
+
 export function createPayFetchWithPreAuth(
   baseFetch: FetchFn,
   client: x402Client,
   ttlMs = DEFAULT_TTL_MS,
-  options?: { skipPreAuth?: boolean; estimateAmount?: EstimateFn },
+  options?: {
+    skipPreAuth?: boolean;
+    estimateAmount?: EstimateFn;
+    onPayment?: (info: PaymentNotification) => void;
+  },
 ): FetchFn {
   const httpClient = new x402HTTPClient(client);
   const cache = new Map<string, CachedEntry>();
@@ -91,6 +97,28 @@ export function createPayFetchWithPreAuth(
       }
     }
     const cacheKey = `${urlPath}:${requestModel}`;
+
+    const notifyAcceptedPayment = (
+      response: Response,
+      payload: { accepted: { amount: string; network: string } },
+    ): void => {
+      const settled =
+        response.headers.has("payment-response") || response.headers.has("x-payment-response");
+      if (!settled || !options?.onPayment) return;
+      try {
+        options.onPayment({
+          model: requestModel,
+          amount: payload.accepted.amount,
+          network: payload.accepted.network,
+        });
+      } catch (error) {
+        // The observer runs after settlement. Its failure must not turn a paid
+        // response into a retryable request and risk a second charge.
+        console.error(
+          `[ClawRouter] onPayment callback failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    };
 
     // Up-front estimate of what THIS request will cost (USDC micro-units), used
     // both to gate pre-auth reuse and to record what a new cache entry covers.
@@ -132,6 +160,7 @@ export function createPayFetchWithPreAuth(
         paymentInFlight = true;
         const response = await baseFetch(preAuthRequest);
         if (response.status !== 402) {
+          notifyAcceptedPayment(response, payload);
           return response; // Pre-auth worked — saved ~200ms
         }
         // Rejected despite our estimate (server priced it higher than we did).
@@ -200,6 +229,8 @@ export function createPayFetchWithPreAuth(
     for (const [key, value] of Object.entries(paymentHeaders)) {
       clonedRequest.headers.set(key, value);
     }
-    return baseFetch(clonedRequest);
+    const paidResponse = await baseFetch(clonedRequest);
+    notifyAcceptedPayment(paidResponse, payload);
+    return paidResponse;
   };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2560,6 +2560,10 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
           // payment still covers the (possibly larger) request — BlockRun prices per
           // token, so one model can cost different amounts across requests.
           estimateAmount,
+          // Only the wallet rail settles per call. The API-key rail is billed
+          // server-side against account credit, so there is no per-request
+          // settlement for an observer to report.
+          onPayment: options.onPayment,
         });
 
   // Create balance monitor for pre-request checks (lazy import to avoid loading @solana/kit on Base chain)


### PR DESCRIPTION
Supersedes #325 — same commit, authored by @twzrd-sol, rebased onto `main`. Opened here because #325's head is on a fork and a rebase needs a force push GitHub will not let a maintainer make.

Closes #321.

`ProxyOptions.onPayment` is declared at `src/proxy.ts:1533` and was invoked nowhere. This puts the notification at the layer that owns both paid paths (normal 402 → signed retry, and cached pre-auth → paid first request), gated on the v2 `PAYMENT-RESPONSE` / v1 `X-PAYMENT-RESPONSE` settlement header. A rejected 402 does not fire it, and an observer that throws cannot turn a paid response into a retry.

### What changed in the rebase

`main` landed the API-key rail (v0.12.268), which routes `authMode === "api-key"` around `createPayFetchWithPreAuth` entirely. `onPayment` is wired on the wallet branch only, with a comment saying why: the API-key rail is billed server-side against account credit, so there is no per-request settlement for an observer to report.

### Known gap, not fixed here

`createApiKeyFetch` (`src/api-key.ts:166-179`) still never notifies. After this lands the documented callback works for wallet users and stays silent for card-funded ones. Worth a follow-up issue.

### Verification (on the rebased tree, merged with the #322 successor)

- `npm run typecheck`, `npm run lint`: clean
- `npm test`: 982 passed, 1 skipped, 0 failed
- `npm run build` + dist smoke: pass
- `npm run test:e2e`: 20 passed, 1 skipped, 0 failed
- `npm run test:e2e:tool-ids`: proxy boots, binds, closes clean

Live-paid e2e skipped (empty wallet). One thing still unproven: no live evidence BlockRun's gateway actually emits the settlement header — the test gateway fabricates it. If it does not, this is inert and every test still passes. A single ~$0.003 probe settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UgUAoQS97qEgVSu1qphFb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payment settlement notifications for successful pre-authorized and standard payment flows.
  * Payment callbacks now report the payment model, settled amount, and network.
  * Added support for receiving settlement notifications through the proxy.

* **Bug Fixes**
  * Observer callback failures no longer cause successful payments to be retried.
  * Settlement notifications are correctly omitted when cached pre-authorization is rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->