### PR TITLE
docs(readme): define BlockRun, not just the router in front of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ Or neither — <!-- br:models.free -->7<!-- /br:models.free --> models are free,
 
 ---
 
+## What BlockRun is
+
+> **BlockRun lets agents pay for the outcome — every LLM, tool and data source, best value per dollar.**
+
+Not a seat, not a subscription, not a monthly minimum you keep paying while the agent idles. An agent asks for one thing — an answer, an image, a transcript, a price, a call placed — and pays for that one thing at the moment it happens. Nothing to sign up for, nothing to cancel.
+
+|                           |                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Every LLM**             | <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> chat models across 9 providers, behind one endpoint and one balance                                                                                                                                                                                                                           |
+| **Every tool**            | <!-- br:models.image -->9<!-- /br:models.image --> image models, <!-- br:models.video -->8<!-- /br:models.video --> video models, music, <!-- br:models.speech -->5<!-- /br:models.speech --> voices, img2img editing, and outbound phone calls that come back as transcripts                                                                                 |
+| **Every data source**     | web, news and neural search; prediction markets; live crypto and equity quotes; on-chain SQL over 100M+ labeled wallets; DEX routing; RPC across <!-- br:chains.rpc -->40<!-- /br:chains.rpc --> chains                                                                                                                                                       |
+| **Best value per dollar** | <!-- br:clawrouter.dimensions -->15<!-- /br:clawrouter.dimensions -->-dimension local routing sends each request to the cheapest model that can actually do it — <!-- br:savings.autoVsBaselinePct -->84<!-- /br:savings.autoVsBaselinePct -->% below pinning Claude Opus 5 on the same traffic, computed from a published workload mix rather than estimated |
+
+**ClawRouter is how an agent reaches it.** BlockRun is the gateway and the billing; ClawRouter is the MIT-licensed router that runs on your machine, decides which model each request deserves, and settles the bill — a wallet signature in USDC, or a credit-card-funded API key. The rest of this README is about ClawRouter.
+
+---
+
 ## Why ClawRouter exists
 
 Every other LLM router was built for **human developers** — create an account, get an API key, pick a model from a dashboard, pay with a credit card.
@@ -867,6 +884,10 @@ Python plugin that wraps the ClawRouter proxy for `hermes-agent`. Same <!-- br:m
 ---
 
 ## Frequently Asked Questions
+
+### What is BlockRun?
+
+BlockRun lets agents pay for the outcome — every LLM, tool and data source, best value per dollar. One endpoint and one balance covering <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> chat models plus image, video, music and speech generation, search, market data and multi-chain RPC, billed per call with USDC over [x402](https://x402.org) or a credit-card-funded API key — no seat, no subscription, no minimum. ClawRouter is the open-source local router agents use to reach it.
 
 ### What is ClawRouter?
 


### PR DESCRIPTION
The README explained ClawRouter thoroughly and never said what BlockRun is. BlockRun appeared exactly once, in passing, as the thing that issues API keys — a reader had to infer the parent from the hostnames.

## What's added

**A `## What BlockRun is` section**, placed before "Why ClawRouter exists" so the parent is established before the product that sits on it:

> **BlockRun lets agents pay for the outcome — every LLM, tool and data source, best value per dollar.**

Then the four claims with the concrete surface behind each one (every LLM / every tool / every data source / best value per dollar), and one paragraph placing ClawRouter as how an agent reaches it.

**A `### What is BlockRun?` FAQ entry**, ahead of "What is ClawRouter?" — that section is the one search engines quote.

## Numbers

Every figure is a brand-numbers marker rather than prose, including the three new to this file (`models.video`, `models.speech`, `chains.rpc`), so they stay in lockstep with the rest of the docs. `node scripts/sync-brand-numbers.mjs --check` → `up to date (10 keys in use)`.

Claims are grounded in surfaces the README already documents: img2img editing, phone calls returned as transcripts, on-chain SQL over 100M+ labeled wallets, and the "76 models across 9 providers" figure already used further down.

## Diff shape

Pure insertions — 21 lines, two hunks, nothing existing reformatted. `prettier --check` clean (README was clean before, and is clean after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UgUAoQS97qEgVSu1qphFb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an overview of BlockRun as a payment and billing layer for agents.
  - Added a comparison of language models, tools, data sources, and value per dollar.
  - Documented ClawRouter’s role as a local router for accessing BlockRun.
  - Added FAQ details about BlockRun’s unified endpoint, balance, and supported payment options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->