### PR TITLE
fix(pricing): sync Grok rates to xAI's published rate (blockrun#503)

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,11 +522,11 @@ No Surf account, no API key — settles directly to Surf's Base treasury in USDC
 | zai/glm-5.2                 |     $1.40 |      $4.40 |    $0.0029 | 1M      | reasoning, coding, tools (flagship)       |
 | zai/glm-5.1                 |     $1.40 |      $4.40 |    $0.0029 | 200K    | reasoning, tools (promo ended 2026-06-05) |
 | qwen/qwen3.7-max            |    $1.475 |     $4.425 |    $0.0030 | 1M      | reasoning, agentic, tools (Qwen flagship) |
-| xai/grok-4.3                |     $1.50 |      $4.00 |    $0.0028 | 1M      | reasoning, vision, agentic, tools         |
+| xai/grok-4.3                |     $1.25 |      $2.50 |    $0.0019 | 1M      | reasoning, vision, agentic, tools         |
 | google/gemini-3.6-flash     |     $1.50 |      $7.50 |    $0.0045 | 1M      | reasoning, vision, tools (newest Flash)   |
 | google/gemini-3.5-flash     |     $1.50 |      $9.00 |    $0.0053 | 1M      | reasoning, vision, tools (thinking)       |
-| xai/grok-4.5                |     $2.50 |      $9.00 |    $0.0058 | 500K    | reasoning, vision, agentic, tools         |
-| xai/grok-build-0.1          |     $1.50 |      $3.00 |    $0.0023 | 256K    | agentic coding, tools                     |
+| xai/grok-4.5                |     $2.00 |      $6.00 |    $0.0040 | 500K    | reasoning, vision, agentic, tools         |
+| xai/grok-build-0.1          |     $1.00 |      $2.00 |    $0.0015 | 256K    | agentic coding, tools                     |
 | openai/gpt-5.2              |     $1.75 |     $14.00 |    $0.0079 | 400K    | reasoning, vision, agentic, tools         |
 | openai/gpt-5.3              |     $1.75 |     $14.00 |    $0.0079 | 128K    | reasoning, vision, agentic, tools         |
 | openai/gpt-5.3-codex        |     $1.75 |     $14.00 |    $0.0079 | 400K    | agentic, tools                            |


### PR DESCRIPTION
Follow-on to blockrun#503 (live in production since 2026-09-04).

Six Grok SKUs on the gateway carried a resale spread over xAI's published rate — up to +140% on output — while the site claimed "provider list price on chat tokens, no markup". The prices were moved rather than the claim, so `blockrun.ai` now bills xAI list on every Grok SKU:

| SKU | was | now |
|---|---|---|
| `xai/grok-4.3` | $1.50 / $4.00 | **$1.25 / $2.50** |
| `xai/grok-4.5` | $2.50 / $9.00 | **$2.00 / $6.00** |
| `xai/grok-build-0.1` | $1.50 / $3.00 | **$1.00 / $2.00** |

Verified against `docs.x.ai/docs/models`; the blockrun-sol agent independently re-checked all 24 numbers (both axes, both tiers) against OpenRouter's live endpoint list.

No price guard reaches this repo — `brand/consumers.json` lists 15 repos and the sweep that catches drift only covers the gateway's own sheets. These were found by grep, not by CI.

**CHANGELOG entries are deliberately unchanged.** A dated entry records what the price was on that day; rewriting it would misreport history. Only live claims and executable values are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChUparsmmkz1GJrvzqmuvL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Lowered the listed per-token prices and estimated per-request costs for `xai/grok-4.3`, `xai/grok-4.5`, and `xai/grok-build-0.1` in the Mid-Range Models pricing table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->