### PR TITLE
feat(x402): opt-in TWZRD AutoGate on existing onBeforePaymentCreation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to ClawRouter.
 
 ---
 
+## Unreleased
+
+### Added — opt-in TWZRD AutoGate on the existing x402 pre-sign hook
+
+Default off. `TWZRD_AUTO_GATE=1` composes `twzrd-x402-gate@0.9.3` (optional
+dependency) into `onBeforePaymentCreation` **after** SpendControl. Missing
+package with the env set is a warn-and-continue; any other load error fails
+closed. Not a re-open of default-on #218. From [#355](https://github.com/BlockRunAI/ClawRouter/issues/355).
+
 ## v0.12.276 — September 6, 2026
 
 ### Fixed — Gemini 3.8 Flash was routable but uncatalogued, which is a cost-cap hole

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -726,6 +726,23 @@ A refusal reaches the caller as HTTP 403 with
 `{"error": {"type": "spend_policy_denied", ...}}`. It is deliberately **not**
 retried against other models: a policy denial is a decision, not an outage.
 
+### TWZRD AutoGate (opt-in)
+
+Default **off**. SpendControl above is the always-available pre-sign hook.
+TWZRD AutoGate is an optional second check on the same
+`onBeforePaymentCreation` chain (wash/preflight against intel.twzrd.xyz).
+
+```bash
+# enable for this process; kill by unsetting
+export TWZRD_AUTO_GATE=1
+npm i twzrd-x402-gate@0.9.3   # optionalDependency; forks may omit it
+```
+
+If the env is set and the package is missing, ClawRouter warns and continues
+(payments unguarded). Any other load error fails closed so the proxy does not
+boot after you asked for a gate that could not install. Identity header:
+`X-Twzrd-Caller: clawrouter@<gate-version>`.
+
 **Scope:** this governs payments made by the proxy. Local tools that sign with
 the same wallet outside the proxy's x402 client (Polymarket funding and order
 placement, `clawrouter doctor`'s probe) are not covered.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/clawrouter",
-  "version": "0.12.262",
+  "version": "0.12.276",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/clawrouter",
-      "version": "0.12.262",
+      "version": "0.12.276",
       "license": "MIT",
       "dependencies": {
         "@blockrun/llm": "^3.10.0",
@@ -24,6 +24,7 @@
         "axios": "^1.18.1",
         "bs58": "^6.0.0",
         "https-proxy-agent": "^9.1.0",
+        "twzrd-x402-gate": "0.9.3",
         "undici": "^8.10.0",
         "viem": "^2.39.3"
       },
@@ -44,6 +45,9 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "twzrd-x402-gate": "^0.9.3"
       },
       "peerDependencies": {
         "openclaw": ">=2025.1.0"
@@ -9930,6 +9934,57 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/twzrd-x402-gate": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/twzrd-x402-gate/-/twzrd-x402-gate-0.9.3.tgz",
+      "integrity": "sha512-Fzlo89R71dD3HfqfyG9VB3oulU9lEQc4R6bsrpkWF3IElVdFv1s5yuo460xY5wkrM0ubnZUrvi5zcEriewQIPQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "twzrd-gate-doctor": "bin/twzrd-gate-doctor.js",
+        "twzrd-gate-eval-refuse": "bin/twzrd-gate-eval-refuse.js",
+        "twzrd-safe-fetch": "bin/twzrd-safe-fetch.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@scure/base": ">=1.0.0",
+        "@solana-program/token": ">=0.9.0",
+        "@solana/kit": ">=5.1.0",
+        "@x402/core": ">=2.0.0",
+        "@x402/fetch": ">=2.0.0",
+        "@x402/svm": ">=2.0.0",
+        "js-sha3": ">=0.8.0",
+        "x402-solana": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@scure/base": {
+          "optional": true
+        },
+        "@solana-program/token": {
+          "optional": true
+        },
+        "@solana/kit": {
+          "optional": true
+        },
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/fetch": {
+          "optional": true
+        },
+        "@x402/svm": {
+          "optional": true
+        },
+        "js-sha3": {
+          "optional": true
+        },
+        "x402-solana": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,9 @@
     "undici": "^8.10.0",
     "viem": "^2.39.3"
   },
+  "optionalDependencies": {
+    "twzrd-x402-gate": "0.9.3"
+  },
   "peerDependencies": {
     "openclaw": ">=2025.1.0"
   },

--- a/src/doctor.spend-policy.test.ts
+++ b/src/doctor.spend-policy.test.ts
@@ -67,7 +67,7 @@ describe("doctor's x402 client enforces spend policy before signing", () => {
   it("refuses a blocked payee and never attaches a payment", async () => {
     const control = new SpendControl({ storage: new InMemorySpendControlStorage() });
     control.setPolicy("blockedPayees", [blockedPayee]);
-    const x402 = createDoctorX402Client({ walletKey: generatePrivateKey(), spendControl: control });
+    const x402 = await createDoctorX402Client({ walletKey: generatePrivateKey(), spendControl: control });
     const paymentFetch = wrapFetchWithPayment(fetch, x402);
 
     await expect(

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -32,6 +32,7 @@ import { getSolanaAddress } from "./wallet.js";
 import { getStats } from "./stats.js";
 import { getProxyPort } from "./proxy.js";
 import { getSharedSpendControl, registerSpendPolicyHook, SpendControl } from "./spend-control.js";
+import { maybeInstallTwzrdAutoGate } from "./twzrd-autogate.js";
 import { VERSION } from "./version.js";
 
 // Types
@@ -508,16 +509,17 @@ const DOCTOR_MODELS: Record<DoctorModel, { id: string; name: string; cost: strin
  * lists. This is the only place doctor constructs an x402Client, so the test
  * that drives it pins the wiring, not just the helper.
  */
-export function createDoctorX402Client(opts: {
+export async function createDoctorX402Client(opts: {
   walletKey: string;
   /** Default: the same on-disk policy the proxy reads. Inject in tests. */
   spendControl?: SpendControl;
-}): x402Client {
+}): Promise<x402Client> {
   const account = privateKeyToAccount(opts.walletKey as `0x${string}`);
   const publicClient = createPublicClient({ chain: base, transport: http() });
   const evmSigner = toClientEvmSigner(account, publicClient);
   const x402 = new x402Client();
   registerSpendPolicyHook(x402, opts.spendControl ?? getSharedSpendControl());
+  await maybeInstallTwzrdAutoGate(x402);
   registerExactEvmScheme(x402, { signer: evmSigner });
   return x402;
 }
@@ -554,7 +556,7 @@ async function analyzeWithAI(
 
   try {
     const { key } = await resolveOrGenerateWalletKey();
-    const x402 = createDoctorX402Client({ walletKey: key });
+    const x402 = await createDoctorX402Client({ walletKey: key });
 
     // Register Solana scheme if user is on Solana chain
     const paymentChain = diagnostics.wallet.paymentChain;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -103,6 +103,7 @@ import {
   SpendControl,
   SpendPolicyError,
 } from "./spend-control.js";
+import { maybeInstallTwzrdAutoGate } from "./twzrd-autogate.js";
 import { compressContext, shouldCompress, type NormalizedMessage } from "./compression/index.js";
 // Balance error classes are available for programmatic use but not used in the
 // proxy (universal free fallback means we don't throw balance errors anymore):
@@ -2797,6 +2798,9 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
     const evmSigner = toClientEvmSigner(account, evmPublicClient);
     const spendControl = options.spendControl ?? getSharedSpendControl();
     registerSpendPolicyHook(x402, spendControl);
+    // Opt-in TWZRD AutoGate (#355): default off. TWZRD_AUTO_GATE=1 composes
+    // into the same onBeforePaymentCreation chain after SpendControl.
+    await maybeInstallTwzrdAutoGate(x402);
     registerExactEvmScheme(x402, { signer: evmSigner });
   }
 

--- a/src/twzrd-autogate.test.ts
+++ b/src/twzrd-autogate.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isTwzrdAutoGateRequested,
+  isTwzrdGateSoftSkip,
+  maybeInstallTwzrdAutoGate,
+} from "./twzrd-autogate.js";
+
+describe("TWZRD AutoGate opt-in (#355)", () => {
+  const prev = process.env.TWZRD_AUTO_GATE;
+
+  afterEach(() => {
+    if (prev === undefined) delete process.env.TWZRD_AUTO_GATE;
+    else process.env.TWZRD_AUTO_GATE = prev;
+  });
+
+  it("is off unless TWZRD_AUTO_GATE is 1/true/on", () => {
+    delete process.env.TWZRD_AUTO_GATE;
+    expect(isTwzrdAutoGateRequested()).toBe(false);
+    process.env.TWZRD_AUTO_GATE = "0";
+    expect(isTwzrdAutoGateRequested()).toBe(false);
+    process.env.TWZRD_AUTO_GATE = "false";
+    expect(isTwzrdAutoGateRequested()).toBe(false);
+    process.env.TWZRD_AUTO_GATE = "1";
+    expect(isTwzrdAutoGateRequested()).toBe(true);
+    process.env.TWZRD_AUTO_GATE = "true";
+    expect(isTwzrdAutoGateRequested()).toBe(true);
+    process.env.TWZRD_AUTO_GATE = "on";
+    expect(isTwzrdAutoGateRequested()).toBe(true);
+  });
+
+  it("skips without loading the gate when env is unset", async () => {
+    delete process.env.TWZRD_AUTO_GATE;
+    const loadGate = vi.fn(async () => {
+      throw new Error("must not load");
+    });
+    const client = { onBeforePaymentCreation() {} };
+    await expect(maybeInstallTwzrdAutoGate(client, { loadGate })).resolves.toBe("skipped");
+    expect(loadGate).not.toHaveBeenCalled();
+  });
+
+  it("installs on the client after opt-in", async () => {
+    process.env.TWZRD_AUTO_GATE = "1";
+    const hooks: unknown[] = [];
+    const client = {
+      onBeforePaymentCreation(hook: unknown) {
+        hooks.push(hook);
+      },
+    };
+    const installTwzrdAutoGate = vi.fn((c: unknown, _opts?: unknown) => {
+      (c as { onBeforePaymentCreation: (h: unknown) => void }).onBeforePaymentCreation(
+        async () => undefined,
+      );
+    });
+    const outcome = await maybeInstallTwzrdAutoGate(client, {
+      loadGate: async () => ({ installTwzrdAutoGate }),
+    });
+    expect(outcome).toBe("installed");
+    expect(installTwzrdAutoGate).toHaveBeenCalledOnce();
+    expect(hooks.length).toBe(1);
+    const opts = installTwzrdAutoGate.mock.calls[0][1] as unknown as {
+      attribution?: { integration: string };
+      refuseWashFlagged?: boolean;
+    };
+    expect(opts.attribution?.integration).toBe("clawrouter");
+    expect(opts.refuseWashFlagged).toBe(true);
+  });
+
+  it("soft-skip matcher only accepts missing twzrd-x402-gate itself", () => {
+    expect(
+      isTwzrdGateSoftSkip(
+        Object.assign(new Error("Cannot find package 'twzrd-x402-gate' imported from /app/proxy.js"), {
+          code: "ERR_MODULE_NOT_FOUND",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTwzrdGateSoftSkip(
+        Object.assign(
+          new Error("Cannot find package 'some-transitive-dep' imported from /app/node_modules/twzrd-x402-gate/index.js"),
+          { code: "ERR_MODULE_NOT_FOUND" },
+        ),
+      ),
+    ).toBe(false);
+    expect(isTwzrdGateSoftSkip(new Error("boom unrelated"))).toBe(false);
+  });
+
+  it("returns missing when the optional package is absent", async () => {
+    process.env.TWZRD_AUTO_GATE = "1";
+    const err = Object.assign(new Error("Cannot find package 'twzrd-x402-gate'"), {
+      code: "ERR_MODULE_NOT_FOUND",
+    });
+    const outcome = await maybeInstallTwzrdAutoGate(
+      { onBeforePaymentCreation() {} },
+      { loadGate: async () => { throw err; } },
+    );
+    expect(outcome).toBe("missing");
+  });
+
+  it("rethrows a non-missing load error (fail closed)", async () => {
+    process.env.TWZRD_AUTO_GATE = "1";
+    await expect(
+      maybeInstallTwzrdAutoGate(
+        { onBeforePaymentCreation() {} },
+        { loadGate: async () => { throw new Error("syntax error in gate"); } },
+      ),
+    ).rejects.toThrow(/syntax error in gate/);
+  });
+});

--- a/src/twzrd-autogate.ts
+++ b/src/twzrd-autogate.ts
@@ -1,0 +1,79 @@
+/**
+ * Opt-in TWZRD AutoGate on an x402 client (#355).
+ *
+ * Default OFF. Set TWZRD_AUTO_GATE=1 (or "true"/"on") to compose
+ * `installTwzrdAutoGate` into the existing onBeforePaymentCreation chain
+ * AFTER SpendControl. This is not a re-open of default-on #218.
+ *
+ * Missing `twzrd-x402-gate` with the env set: warn and continue (fail open).
+ * Any other load/register error: throw (fail closed — do not boot unguarded
+ * after the operator asked for the gate).
+ */
+export type X402ClientLike = {
+  onBeforePaymentCreation: (...args: never[]) => unknown;
+};
+
+export type TwzrdAutoGateOutcome = "skipped" | "missing" | "installed";
+
+export type GateModule = {
+  installTwzrdAutoGate: (client: unknown, options?: unknown) => unknown;
+};
+
+export type MaybeInstallTwzrdAutoGateDeps = {
+  /** Injectable for tests. Default: dynamic import("twzrd-x402-gate"). */
+  loadGate?: () => Promise<GateModule>;
+};
+
+/** True only for an explicit opt-in. Unset / 0 / false / off → skipped. */
+export function isTwzrdAutoGateRequested(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = (env.TWZRD_AUTO_GATE ?? "").trim().toLowerCase();
+  return v === "1" || v === "true" || v === "on";
+}
+
+/** Soft-skip only when the absent package is twzrd-x402-gate itself. */
+export function isTwzrdGateSoftSkip(err: unknown): boolean {
+  const code = (err as { code?: string } | null)?.code;
+  const msg = err instanceof Error ? err.message : String(err);
+  const missingModule =
+    code === "ERR_MODULE_NOT_FOUND" ||
+    code === "MODULE_NOT_FOUND" ||
+    /Cannot find module/i.test(msg) ||
+    /Cannot find package/i.test(msg);
+  return Boolean(missingModule && /['"]twzrd-x402-gate['"]/i.test(msg));
+}
+
+async function defaultLoadGate(): Promise<GateModule> {
+  return import("twzrd-x402-gate") as Promise<GateModule>;
+}
+
+export async function maybeInstallTwzrdAutoGate(
+  client: X402ClientLike,
+  deps: MaybeInstallTwzrdAutoGateDeps = {},
+): Promise<TwzrdAutoGateOutcome> {
+  if (!isTwzrdAutoGateRequested()) {
+    return "skipped";
+  }
+  let gate: GateModule;
+  try {
+    gate = await (deps.loadGate ?? defaultLoadGate)();
+  } catch (err) {
+    if (isTwzrdGateSoftSkip(err)) {
+      console.warn(
+        "[ClawRouter] TWZRD_AUTO_GATE=1 but twzrd-x402-gate is not installed — payments unguarded. npm i twzrd-x402-gate@0.9.3",
+      );
+      return "missing";
+    }
+    throw err;
+  }
+  gate.installTwzrdAutoGate(client, {
+    refuseWashFlagged: true,
+    gateOnCanSpend: false,
+    unsupportedNetworkMode: "observe",
+    attribution: {
+      integration: "clawrouter",
+      runId: process.env.TWZRD_RUN_ID || "clawrouter",
+    },
+  });
+  console.log("[ClawRouter] TWZRD AutoGate ON (opt-in). Kill: unset TWZRD_AUTO_GATE");
+  return "installed";
+}

--- a/src/twzrd-x402-gate.d.ts
+++ b/src/twzrd-x402-gate.d.ts
@@ -1,0 +1,4 @@
+declare module "twzrd-x402-gate" {
+  export function installTwzrdAutoGate(client: unknown, options?: unknown): unknown;
+  export function isTwzrdAutoGateDisabled(options?: { disabled?: boolean }): boolean;
+}


### PR DESCRIPTION
Fixes #355. Not a re-open of default-on #218.

## What

SpendControl already owns `x402.onBeforePaymentCreation`. This adds an **opt-in** second check on that same chain, **after** `registerSpendPolicyHook`:

- Default **off**. Unset / `0` / `false` never loads `twzrd-x402-gate`.
- `TWZRD_AUTO_GATE=1` (or `true`/`on`) dynamically imports `twzrd-x402-gate@0.9.3` (`optionalDependencies`) and calls `installTwzrdAutoGate` with `refuseWashFlagged: true`, Base/EVM observe, attribution `clawrouter` (stamps `X-Twzrd-Caller: clawrouter@<gate-version>`).
- Env set + package missing: warn, continue (fail open). Any other load error: throw (fail closed).
- Wired in `startProxy` (wallet rail) and `createDoctorX402Client` so doctor is not a bypass.

Kill: unset `TWZRD_AUTO_GATE`.

## Tests

`npx vitest run src/twzrd-autogate.test.ts src/doctor.spend-policy.test.ts` — 7 passed.
`npx tsc --noEmit` clean.

## Docs

`docs/configuration.md` — short opt-in section under Spend Control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in TWZRD AutoGate for proxy x402 payments.
  - Enable it with `TWZRD_AUTO_GATE=1`, `true`, or `on`.
  - Adds payment preflight checks and caller identity attribution.
  - Missing optional gate package produces a warning; other loading failures prevent proxy startup.

- **Documentation**
  - Added configuration and unreleased-change documentation for AutoGate behavior and setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->