### PR TITLE
feat(x402): opt-in TWZRD AutoGate after SpendControl (#355)

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,8 +767,21 @@ For basic usage, no configuration needed. For advanced options:
 | `CLAWROUTER_DISABLED`       | `false`                               | Disable smart routing                                                                                                       |
 | `CLAWROUTER_DEBUG_HEADERS`  | `on`                                  | Set to `off` to suppress `x-clawrouter-*` debug response headers                                                            |
 | `CLAWROUTER_SOLANA_RPC_URL` | `https://api.mainnet-beta.solana.com` | Solana RPC endpoint — balance checks and payment signing                                                                    |
+| `TWZRD_AUTO_GATE`           | unset (off)                           | Set to `1` to compose TWZRD AutoGate after SpendControl on the x402 pre-sign hook                                           |
 
 **Full reference:** [docs/configuration.md](docs/configuration.md)
+
+### Pre-spend trust (TWZRD AutoGate, opt-in)
+
+Default **off**. Spend limits and counterparty lists (`clawrouter policy`) stay the vendor-neutral path. This is not a default-on vendor lock.
+
+To also run TWZRD wash/preflight on the same `onBeforePaymentCreation` chain — after SpendControl, before the wallet signs:
+
+```bash
+export TWZRD_AUTO_GATE=1
+```
+
+Equivalent flag: `TWZRD_GATE_ENABLED=true`. Requires optional dependency `twzrd-x402-gate@0.9.3` (forks that omit it still install). A refuse stamps `X-Twzrd-Caller: clawrouter/<version>` so it is attributable. Unset the flag to go back to SpendControl only.
 
 ### Model Exclusion
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ Complete reference for ClawRouter configuration options.
 - [Tier Overrides](#tier-overrides)
 - [Scoring Weights](#scoring-weights)
 - [Spend Control & Counterparty Policy](#spend-control--counterparty-policy)
+- [TWZRD AutoGate (opt-in)](#twzrd-autogate-opt-in)
 - [Testing Configuration](#testing-configuration)
 
 ---
@@ -32,6 +33,7 @@ Complete reference for ClawRouter configuration options.
 | `CLAWROUTER_WORKER`         | -                                     | Set to `1` to enable Worker Mode (earn USDC by running health checks).                                                                                      |
 | `CLAWROUTER_DEBUG_HEADERS`  | (on)                                  | Set to `off`/`false`/`0` to suppress the `x-clawrouter-*` debug response headers.                                                                           |
 | `BLOCKRUN_WEB_SEARCH`       | (auto-enabled)                        | Set to `off` to disable BlockRun's Exa web search provider registration.                                                                                    |
+| `TWZRD_AUTO_GATE`           | unset (off)                           | Set to `1` to compose TWZRD AutoGate after SpendControl on the x402 pre-sign hook. Also `TWZRD_GATE_ENABLED=true`.                                          |
 
 ---
 
@@ -729,6 +731,31 @@ retried against other models: a policy denial is a decision, not an outage.
 **Scope:** this governs payments made by the proxy. Local tools that sign with
 the same wallet outside the proxy's x402 client (Polymarket funding and order
 placement, `clawrouter doctor`'s probe) are not covered.
+
+---
+
+## TWZRD AutoGate (opt-in)
+
+Default **off**. This is not a re-open of default-on vendor lock. SpendControl
+above remains the vendor-neutral path; TWZRD is composed only when you ask.
+
+```bash
+export TWZRD_AUTO_GATE=1
+# equivalent:
+export TWZRD_GATE_ENABLED=true
+```
+
+When set, `startProxy` calls `installTwzrdAutoGate` / `createTwzrdBeforePaymentHook`
+on the **same** x402 client, **after** `registerSpendPolicyHook`. SpendControl
+lists still run first. A wash `payTo` is refused before `signTransaction`.
+
+- Optional dependency: `twzrd-x402-gate@0.9.3`. Forks that omit it still install.
+- Missing gate package (`MODULE_NOT_FOUND` for `twzrd-x402-gate` itself): fail
+  open — proxy boots, payments unguarded by TWZRD. Any other load/install error
+  fails closed.
+- Identity: preflight stamps `X-Twzrd-Caller: clawrouter/<version>` so a refuse
+  is attributable.
+- Unset the flag to return to SpendControl only.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/clawrouter",
-  "version": "0.12.262",
+  "version": "0.12.276",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/clawrouter",
-      "version": "0.12.262",
+      "version": "0.12.276",
       "license": "MIT",
       "dependencies": {
         "@blockrun/llm": "^3.10.0",
@@ -44,6 +44,9 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "twzrd-x402-gate": "0.9.3"
       },
       "peerDependencies": {
         "openclaw": ">=2025.1.0"
@@ -9930,6 +9933,57 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/twzrd-x402-gate": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/twzrd-x402-gate/-/twzrd-x402-gate-0.9.3.tgz",
+      "integrity": "sha512-Fzlo89R71dD3HfqfyG9VB3oulU9lEQc4R6bsrpkWF3IElVdFv1s5yuo460xY5wkrM0ubnZUrvi5zcEriewQIPQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "twzrd-gate-doctor": "bin/twzrd-gate-doctor.js",
+        "twzrd-gate-eval-refuse": "bin/twzrd-gate-eval-refuse.js",
+        "twzrd-safe-fetch": "bin/twzrd-safe-fetch.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@scure/base": ">=1.0.0",
+        "@solana-program/token": ">=0.9.0",
+        "@solana/kit": ">=5.1.0",
+        "@x402/core": ">=2.0.0",
+        "@x402/fetch": ">=2.0.0",
+        "@x402/svm": ">=2.0.0",
+        "js-sha3": ">=0.8.0",
+        "x402-solana": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@scure/base": {
+          "optional": true
+        },
+        "@solana-program/token": {
+          "optional": true
+        },
+        "@solana/kit": {
+          "optional": true
+        },
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/fetch": {
+          "optional": true
+        },
+        "@x402/svm": {
+          "optional": true
+        },
+        "js-sha3": {
+          "optional": true
+        },
+        "x402-solana": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,9 @@
     "undici": "^8.10.0",
     "viem": "^2.39.3"
   },
+  "optionalDependencies": {
+    "twzrd-x402-gate": "0.9.3"
+  },
   "peerDependencies": {
     "openclaw": ">=2025.1.0"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,6 +112,7 @@ Environment Variables:
   BLOCKRUN_API_KEY        BlockRun API key (brk_...) — wins over the wallet when set
   BLOCKRUN_WALLET_KEY     Private key for x402 payments (auto-generated if not set)
   BLOCKRUN_PROXY_PORT     Default proxy port (default: 8402)
+  TWZRD_AUTO_GATE         Set to 1 to compose TWZRD AutoGate after SpendControl (default off)
 
 For more info: https://blockrun.ai/clawrouter.md
 `);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -103,6 +103,7 @@ import {
   SpendControl,
   SpendPolicyError,
 } from "./spend-control.js";
+import { maybeComposeTwzrdAutoGate } from "./twzrd-autogate.js";
 import { compressContext, shouldCompress, type NormalizedMessage } from "./compression/index.js";
 // Balance error classes are available for programmatic use but not used in the
 // proxy (universal free fallback means we don't throw balance errors anymore):
@@ -2797,6 +2798,8 @@ export async function startProxy(options: ProxyOptions): Promise<ProxyHandle> {
     const evmSigner = toClientEvmSigner(account, evmPublicClient);
     const spendControl = options.spendControl ?? getSharedSpendControl();
     registerSpendPolicyHook(x402, spendControl);
+    // Opt-in only (TWZRD_AUTO_GATE=1). Default off — does not replace SpendControl.
+    await maybeComposeTwzrdAutoGate(x402);
     registerExactEvmScheme(x402, { signer: evmSigner });
   }
 

--- a/src/twzrd-autogate.test.ts
+++ b/src/twzrd-autogate.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  isMissingTwzrdGateModule,
+  isTwzrdAutoGateEnabled,
+  maybeComposeTwzrdAutoGate,
+  twzrdAutoGateInstallOptions,
+  type BeforePaymentCreationContext,
+  type BeforePaymentCreationResult,
+  type X402ClientLike,
+} from "./twzrd-autogate.js";
+import { VERSION } from "./version.js";
+
+function fakeClient(): {
+  client: X402ClientLike;
+  hooks: Array<(ctx: BeforePaymentCreationContext) => Promise<BeforePaymentCreationResult>>;
+} {
+  const hooks: Array<(ctx: BeforePaymentCreationContext) => Promise<BeforePaymentCreationResult>> =
+    [];
+  const client: X402ClientLike = {
+    onBeforePaymentCreation(hook) {
+      hooks.push(hook);
+    },
+  };
+  return { client, hooks };
+}
+
+describe("isTwzrdAutoGateEnabled", () => {
+  it("is off by default when both flags are unset", () => {
+    expect(isTwzrdAutoGateEnabled({})).toBe(false);
+  });
+
+  it("opts in on TWZRD_AUTO_GATE=1", () => {
+    expect(isTwzrdAutoGateEnabled({ TWZRD_AUTO_GATE: "1" })).toBe(true);
+  });
+
+  it("opts in on TWZRD_GATE_ENABLED=true", () => {
+    expect(isTwzrdAutoGateEnabled({ TWZRD_GATE_ENABLED: "true" })).toBe(true);
+  });
+
+  it("treats true/yes/on as enable and 0/false as disable", () => {
+    expect(isTwzrdAutoGateEnabled({ TWZRD_AUTO_GATE: "yes" })).toBe(true);
+    expect(isTwzrdAutoGateEnabled({ TWZRD_AUTO_GATE: "on" })).toBe(true);
+    expect(isTwzrdAutoGateEnabled({ TWZRD_AUTO_GATE: "0" })).toBe(false);
+    expect(isTwzrdAutoGateEnabled({ TWZRD_AUTO_GATE: "false" })).toBe(false);
+    expect(isTwzrdAutoGateEnabled({ TWZRD_GATE_ENABLED: "off" })).toBe(false);
+  });
+
+  it("lets an explicit disable win over an enable on the other flag", () => {
+    expect(isTwzrdAutoGateEnabled({ TWZRD_AUTO_GATE: "1", TWZRD_GATE_ENABLED: "false" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("isMissingTwzrdGateModule", () => {
+  it("matches only a missing twzrd-x402-gate package", () => {
+    expect(
+      isMissingTwzrdGateModule(
+        Object.assign(
+          new Error("Cannot find package 'twzrd-x402-gate' imported from /app/proxy.js"),
+          {
+            code: "ERR_MODULE_NOT_FOUND",
+          },
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isMissingTwzrdGateModule(
+        Object.assign(
+          new Error(
+            "Cannot find package 'some-transitive-dep' imported from /app/node_modules/twzrd-x402-gate/index.js",
+          ),
+          { code: "ERR_MODULE_NOT_FOUND" },
+        ),
+      ),
+    ).toBe(false);
+    expect(isMissingTwzrdGateModule(new Error("boom unrelated"))).toBe(false);
+  });
+});
+
+describe("twzrdAutoGateInstallOptions", () => {
+  it("stamps clawrouter/<version> so a refuse is attributable", () => {
+    const opts = twzrdAutoGateInstallOptions(() => "run-1");
+    expect(opts.attribution.integration).toBe(`clawrouter/${VERSION}`);
+    expect(opts.attribution.runId).toBe("run-1");
+    expect(opts.refuseWashFlagged).toBe(true);
+    expect(opts.gateOnCanSpend).toBe(false);
+    expect(opts.unsupportedNetworkMode).toBe("observe");
+  });
+});
+
+describe("maybeComposeTwzrdAutoGate", () => {
+  const prevAuto = process.env.TWZRD_AUTO_GATE;
+  const prevGate = process.env.TWZRD_GATE_ENABLED;
+
+  afterEach(() => {
+    if (prevAuto === undefined) delete process.env.TWZRD_AUTO_GATE;
+    else process.env.TWZRD_AUTO_GATE = prevAuto;
+    if (prevGate === undefined) delete process.env.TWZRD_GATE_ENABLED;
+    else process.env.TWZRD_GATE_ENABLED = prevGate;
+  });
+
+  it("does not load or register anything on the default path", async () => {
+    const loadGate = vi.fn();
+    const { client, hooks } = fakeClient();
+    const spendHook = async () => undefined;
+    client.onBeforePaymentCreation(spendHook);
+
+    const result = await maybeComposeTwzrdAutoGate(client, {
+      env: {},
+      loadGate,
+      log: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(result).toEqual({ status: "skipped" });
+    expect(loadGate).not.toHaveBeenCalled();
+    expect(hooks).toEqual([spendHook]);
+  });
+
+  it("composes installTwzrdAutoGate after an existing SpendControl hook", async () => {
+    const { client, hooks } = fakeClient();
+    const spendHook = async () => undefined;
+    client.onBeforePaymentCreation(spendHook);
+
+    let invoked = 0;
+    const installTwzrdAutoGate = vi.fn((x402: X402ClientLike) => {
+      x402.onBeforePaymentCreation(async () => {
+        invoked += 1;
+      });
+    });
+
+    const result = await maybeComposeTwzrdAutoGate(client, {
+      env: { TWZRD_AUTO_GATE: "1" },
+      loadGate: async () => ({ installTwzrdAutoGate }),
+      log: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(result).toEqual({ status: "composed", via: "installTwzrdAutoGate" });
+    expect(installTwzrdAutoGate).toHaveBeenCalledTimes(1);
+    expect(hooks[0]).toBe(spendHook);
+    expect(hooks).toHaveLength(2);
+
+    await hooks[1]!({
+      selectedRequirements: { payTo: "Seller1111111111111111111111111111111111111" },
+    });
+    expect(invoked).toBe(1);
+    expect(installTwzrdAutoGate.mock.calls[0]?.[1]?.attribution.integration).toBe(
+      `clawrouter/${VERSION}`,
+    );
+  });
+
+  it("falls back to createTwzrdBeforePaymentHook and invokes it", async () => {
+    const { client, hooks } = fakeClient();
+    const seen: unknown[] = [];
+    const createTwzrdBeforePaymentHook = vi.fn(() => {
+      return async (requirements: Record<string, unknown>) => {
+        seen.push(requirements);
+        return { abort: true as const, reason: "wash" };
+      };
+    });
+
+    const result = await maybeComposeTwzrdAutoGate(client, {
+      env: { TWZRD_AUTO_GATE: "1" },
+      loadGate: async () => ({ createTwzrdBeforePaymentHook }),
+      log: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(result).toEqual({ status: "composed", via: "createTwzrdBeforePaymentHook" });
+    const abort = await hooks[0]!({ selectedRequirements: { payTo: "wash" } });
+    expect(abort).toEqual({ abort: true, reason: "wash" });
+    expect(seen).toEqual([{ payTo: "wash" }]);
+  });
+
+  it("fails open only when twzrd-x402-gate itself is missing", async () => {
+    const warn = vi.fn();
+    const result = await maybeComposeTwzrdAutoGate(fakeClient().client, {
+      env: { TWZRD_AUTO_GATE: "1" },
+      loadGate: async () => {
+        throw Object.assign(new Error("Cannot find package 'twzrd-x402-gate' imported from /app"), {
+          code: "ERR_MODULE_NOT_FOUND",
+        });
+      },
+      log: { log: vi.fn(), warn },
+    });
+    expect(result.status).toBe("unavailable");
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("fails closed on a real module error", async () => {
+    await expect(
+      maybeComposeTwzrdAutoGate(fakeClient().client, {
+        env: { TWZRD_AUTO_GATE: "1" },
+        loadGate: async () => {
+          throw new Error("unexpected gate init failure");
+        },
+        log: { log: vi.fn(), warn: vi.fn() },
+      }),
+    ).rejects.toThrow("unexpected gate init failure");
+  });
+});

--- a/src/twzrd-autogate.test.ts
+++ b/src/twzrd-autogate.test.ts
@@ -7,6 +7,7 @@ import {
   twzrdAutoGateInstallOptions,
   type BeforePaymentCreationContext,
   type BeforePaymentCreationResult,
+  type TwzrdGateInstallOptions,
   type X402ClientLike,
 } from "./twzrd-autogate.js";
 import { VERSION } from "./version.js";
@@ -124,7 +125,8 @@ describe("maybeComposeTwzrdAutoGate", () => {
     client.onBeforePaymentCreation(spendHook);
 
     let invoked = 0;
-    const installTwzrdAutoGate = vi.fn((x402: X402ClientLike) => {
+    const installTwzrdAutoGate = vi.fn((x402: X402ClientLike, opts?: TwzrdGateInstallOptions) => {
+      expect(opts?.attribution.integration).toBe(`clawrouter/${VERSION}`);
       x402.onBeforePaymentCreation(async () => {
         invoked += 1;
       });
@@ -145,9 +147,6 @@ describe("maybeComposeTwzrdAutoGate", () => {
       selectedRequirements: { payTo: "Seller1111111111111111111111111111111111111" },
     });
     expect(invoked).toBe(1);
-    expect(installTwzrdAutoGate.mock.calls[0]?.[1]?.attribution.integration).toBe(
-      `clawrouter/${VERSION}`,
-    );
   });
 
   it("falls back to createTwzrdBeforePaymentHook and invokes it", async () => {

--- a/src/twzrd-autogate.ts
+++ b/src/twzrd-autogate.ts
@@ -1,0 +1,167 @@
+/**
+ * Opt-in TWZRD AutoGate on the existing x402 onBeforePaymentCreation chain.
+ *
+ * Default OFF. SpendControl remains the vendor-neutral path (#205 / #268 / #304).
+ * This is not a re-open of withdrawn #218 (default-on vendor lock).
+ *
+ * When TWZRD_AUTO_GATE=1 (or TWZRD_GATE_ENABLED=true), compose
+ * installTwzrdAutoGate / createTwzrdBeforePaymentHook AFTER registerSpendPolicyHook
+ * so a wash payTo is refused before sign. Identity header:
+ *   X-Twzrd-Caller: clawrouter/<version>
+ *
+ * Fail closed on a real module error; fail open only when twzrd-x402-gate itself
+ * is missing (optionalDependency — forks may omit it).
+ */
+
+import { randomUUID } from "node:crypto";
+import { VERSION } from "./version.js";
+
+export const TWZRD_GATE_PACKAGE = "twzrd-x402-gate";
+
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+const FALSY = new Set(["0", "false", "no", "off"]);
+
+export type BeforePaymentCreationResult = void | { abort: true; reason: string };
+
+export type BeforePaymentCreationContext = {
+  selectedRequirements: Record<string, unknown>;
+  paymentRequired?: unknown;
+};
+
+export type X402ClientLike = {
+  onBeforePaymentCreation: (
+    hook: (context: BeforePaymentCreationContext) => Promise<BeforePaymentCreationResult>,
+  ) => unknown;
+};
+
+export type TwzrdGateInstallOptions = {
+  refuseWashFlagged: boolean;
+  gateOnCanSpend: boolean;
+  unsupportedNetworkMode: "observe" | "strict";
+  attribution: { integration: string; runId: string };
+};
+
+export type TwzrdGateModule = {
+  installTwzrdAutoGate?: (client: X402ClientLike, options?: TwzrdGateInstallOptions) => unknown;
+  createTwzrdBeforePaymentHook?: (
+    options?: TwzrdGateInstallOptions,
+  ) => (
+    requirements: Record<string, unknown>,
+    context?: unknown,
+  ) => Promise<BeforePaymentCreationResult>;
+};
+
+export type LoadTwzrdGate = () => Promise<TwzrdGateModule>;
+
+export type ComposeTwzrdAutoGateResult =
+  | { status: "skipped" }
+  | { status: "composed"; via: "installTwzrdAutoGate" | "createTwzrdBeforePaymentHook" }
+  | { status: "unavailable"; reason: string };
+
+function normalizeFlag(value: string | undefined): string | undefined {
+  const trimmed = value?.trim().toLowerCase();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+/**
+ * True only when an operator explicitly opts in. Unset is off.
+ * An explicit disable (`0` / `false` / `no` / `off`) on either flag wins.
+ */
+export function isTwzrdAutoGateEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const auto = normalizeFlag(env.TWZRD_AUTO_GATE);
+  const gate = normalizeFlag(env.TWZRD_GATE_ENABLED);
+  if ((auto !== undefined && FALSY.has(auto)) || (gate !== undefined && FALSY.has(gate))) {
+    return false;
+  }
+  return (auto !== undefined && TRUTHY.has(auto)) || (gate !== undefined && TRUTHY.has(gate));
+}
+
+/** Fail-open only when the absent package is the optional gate itself. */
+export function isMissingTwzrdGateModule(err: unknown): boolean {
+  const code = (err as { code?: string } | null)?.code;
+  const msg = err instanceof Error ? err.message : String(err);
+  const missingModule =
+    code === "ERR_MODULE_NOT_FOUND" ||
+    code === "MODULE_NOT_FOUND" ||
+    /Cannot find module/i.test(msg) ||
+    /Cannot find package/i.test(msg);
+  return missingModule && new RegExp(String.raw`['"]${TWZRD_GATE_PACKAGE}['"]`).test(msg);
+}
+
+export function twzrdAutoGateInstallOptions(
+  runId: () => string = randomUUID,
+): TwzrdGateInstallOptions {
+  return {
+    refuseWashFlagged: true,
+    gateOnCanSpend: false,
+    unsupportedNetworkMode: "observe",
+    attribution: {
+      integration: `clawrouter/${VERSION}`,
+      runId: runId(),
+    },
+  };
+}
+
+export async function defaultLoadTwzrdGate(): Promise<TwzrdGateModule> {
+  // Variable specifier so tsup/esbuild cannot statically inline the optional dep
+  // (the build uses noExternal: [/.*/]).
+  const specifier: string = TWZRD_GATE_PACKAGE;
+  return import(specifier) as Promise<TwzrdGateModule>;
+}
+
+/**
+ * Compose TWZRD onto an x402 client that already has SpendControl registered.
+ * Does nothing unless the opt-in flag is set. Never replaces SpendControl.
+ */
+export async function maybeComposeTwzrdAutoGate(
+  x402: X402ClientLike,
+  options?: {
+    env?: NodeJS.ProcessEnv;
+    loadGate?: LoadTwzrdGate;
+    log?: Pick<Console, "log" | "warn">;
+  },
+): Promise<ComposeTwzrdAutoGateResult> {
+  const env = options?.env ?? process.env;
+  const log = options?.log ?? console;
+  if (!isTwzrdAutoGateEnabled(env)) {
+    return { status: "skipped" };
+  }
+
+  const load = options?.loadGate ?? defaultLoadTwzrdGate;
+  let gate: TwzrdGateModule;
+  try {
+    gate = await load();
+  } catch (err) {
+    if (isMissingTwzrdGateModule(err)) {
+      const reason = `${TWZRD_GATE_PACKAGE} is not installed`;
+      log.warn(
+        `[ClawRouter] TWZRD AutoGate opted in but ${reason} — skipping. npm i ${TWZRD_GATE_PACKAGE}@0.9.3`,
+      );
+      return { status: "unavailable", reason };
+    }
+    throw err;
+  }
+
+  const installOpts = twzrdAutoGateInstallOptions();
+
+  if (typeof gate.installTwzrdAutoGate === "function") {
+    gate.installTwzrdAutoGate(x402, installOpts);
+    log.log(
+      "[ClawRouter] TWZRD AutoGate ON (opt-in, after SpendControl). Unset TWZRD_AUTO_GATE to disable.",
+    );
+    return { status: "composed", via: "installTwzrdAutoGate" };
+  }
+
+  if (typeof gate.createTwzrdBeforePaymentHook === "function") {
+    const hook = gate.createTwzrdBeforePaymentHook(installOpts);
+    x402.onBeforePaymentCreation(async (ctx) => hook(ctx.selectedRequirements, ctx));
+    log.log(
+      "[ClawRouter] TWZRD AutoGate ON (opt-in, after SpendControl). Unset TWZRD_AUTO_GATE to disable.",
+    );
+    return { status: "composed", via: "createTwzrdBeforePaymentHook" };
+  }
+
+  throw new Error(
+    `[ClawRouter] ${TWZRD_GATE_PACKAGE} is installed but exports neither installTwzrdAutoGate nor createTwzrdBeforePaymentHook`,
+  );
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,7 +11,11 @@ export default defineConfig({
   target: "node22",
   splitting: false,
   noExternal: [/.*/],
-  external: [...builtinModules.flatMap((m) => [m, `node:${m}`])],
+  external: [
+    ...builtinModules.flatMap((m) => [m, `node:${m}`]),
+    // Optional, default-off. Must stay a runtime import so forks can omit it.
+    "twzrd-x402-gate",
+  ],
   esbuildOptions(options) {
     // We and @blockrun/llm depend on each other, and `noExternal` inlines it. Its
     // `import { route, ... } from "@blockrun/clawrouter"` therefore resolves through


### PR DESCRIPTION
Closes #355.

Opt-in TWZRD AutoGate on the existing x402 `onBeforePaymentCreation` hook. **Default off.** Not a re-open of withdrawn #218 (default-on vendor lock). SpendControl (#205 / #268 / #304) stays the vendor-neutral path; this only composes TWZRD when explicitly enabled.

## Behavior

1. Default: unchanged — no TWZRD AutoGate, no extra import.
2. `TWZRD_AUTO_GATE=1` (or `TWZRD_GATE_ENABLED=true`) calls `installTwzrdAutoGate` / `createTwzrdBeforePaymentHook` **after** `registerSpendPolicyHook` on the same client. SpendControl lists still run first.
3. Optional dependency `twzrd-x402-gate@0.9.3` so forks that omit it still install.
4. Fail open only when that package itself is `MODULE_NOT_FOUND`. Any other load/install error fails closed.
5. Attribution: `X-Twzrd-Caller: clawrouter/<version>` so a refuse is attributable.

## Docs

README + `docs/configuration.md`: opt-in, default off, how to enable.

## Tests

`src/twzrd-autogate.test.ts`: default path does not load or register; with the flag the hook is composed and invoked; missing package fails open; other errors fail closed.

Verified: `tsc --noEmit`, `eslint src/`, `vitest run` (1100 passed, 1 skipped), `npm run build` (dynamic `import("twzrd-x402-gate")` stays unbundled).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional TWZRD AutoGate protection for EVM x402 payments.
  * Enable it with `TWZRD_AUTO_GATE=1` or `TWZRD_GATE_ENABLED=true`; it is disabled by default.
  * Payment checks run after SpendControl and can refuse payments before transaction signing.
  * Requests include a TWZRD caller identity stamp.
* **Documentation**
  * Added configuration reference, CLI help, and setup guidance for enabling AutoGate.
  * Documented behavior when AutoGate is unavailable or encounters loading errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->