### PR TITLE
deps: @solana/kit 5.5.1 → 8.2.0 (takes the content-length fix from upstream)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/clawrouter",
-  "version": "0.12.262",
+  "version": "0.12.276",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/clawrouter",
-      "version": "0.12.262",
+      "version": "0.12.276",
       "license": "MIT",
       "dependencies": {
         "@blockrun/llm": "^3.10.0",
@@ -16,7 +16,7 @@
         "@polymarket/clob-client-v2": "1.0.8",
         "@scure/bip32": "^2.0.1",
         "@scure/bip39": "^1.5.0",
-        "@solana/kit": "^5.0.0",
+        "@solana/kit": "^8.0.0",
         "@x402/core": "^2.9.0",
         "@x402/evm": "^2.9.0",
         "@x402/fetch": "^2.9.0",
@@ -2845,51 +2845,69 @@
       }
     },
     "node_modules/@solana-program/compute-budget": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.11.0.tgz",
-      "integrity": "sha512-7f1ePqB/eURkTwTOO9TNIdUXZcyrZoX3Uy2hNo7cXMfNhPFWp9AVgIyRNBc2jf15sdUa9gNpW+PfP2iV8AYAaw==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.18.1.tgz",
+      "integrity": "sha512-ZVWknu3XvF6NI3zAuT6TXV19lQ7iDPzToM9gwI6KnUlnzHHP3u7IAIzDM7hLueQ6T7vLGjIUjYFCVg4mLHRZcg==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@solana/kit": "^5.0"
+        "@solana/kit": "^8.0.0"
+      }
+    },
+    "node_modules/@solana-program/record": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/record/-/record-0.4.1.tgz",
+      "integrity": "sha512-3iurtMAc3POMKVSZBqpNZQeoxAYVIxi0VZNOjkdaZqxr5glCxkWWruT8JekDwNFM0FnXxvtdu7tFFn3j6Kpegg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana-program/system": "^0.14.0"
+      },
+      "peerDependencies": {
+        "@solana/kit": "^8.0.0"
+      }
+    },
+    "node_modules/@solana-program/system": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.14.1.tgz",
+      "integrity": "sha512-K6ZiIrAKoJAfcwfUdsoFvfSAxeRJaRrV7BPFTJvUVRS4m3zszN+nLcdaNMMe2F1/zTriZqC+xh+Kgw6ziGUqpQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^8.0.0"
       }
     },
     "node_modules/@solana-program/token": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.9.0.tgz",
-      "integrity": "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.16.1.tgz",
+      "integrity": "sha512-X9dsvbh+VDq4SuCfvxn95P1DCvtBYHJOBiVmgBJMfW8l/lp8uSwEhy9IurpcdltnGi5kNIkCm4sk4YOXKAMiCw==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@solana-program/system": "^0.14.0"
+      },
       "peerDependencies": {
-        "@solana/kit": "^5.0"
+        "@solana/kit": "^8.0.0"
       }
     },
-    "node_modules/@solana-program/token-2022": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.6.1.tgz",
-      "integrity": "sha512-Ex02cruDMGfBMvZZCrggVR45vdQQSI/unHVpt/7HPt/IwFYB4eTlXtO8otYZyqV/ce5GqZ8S6uwyRf0zy6fdbA==",
+    "node_modules/@solana-program/zk-elgamal-proof": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/zk-elgamal-proof/-/zk-elgamal-proof-0.4.0.tgz",
+      "integrity": "sha512-bf2Q3f25xcCNaLm/MR4lwoAguJzEW2eeLdrJb6rUjMcA63qcgyJOWl6To7Bn4e+0OyWBa+J7YP2BUhi//VPz3g==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@solana-program/system": "^0.14.0"
+      },
       "peerDependencies": {
-        "@solana/kit": "^5.0",
-        "@solana/sysvars": "^5.0"
+        "@solana/kit": "^8.0.0"
       }
     },
-    "node_modules/@solana/accounts": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
-      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-8.2.0.tgz",
+      "integrity": "sha512-OND76Qsng/fiTVSUvaNZFv0WKEULlwcGRtgeIE2keA2xYoHYNTSoD6mxv4iWANfeDo4EH7D/HnOwnGEFXMjr9w==",
       "license": "MIT",
-      "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-spec": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
-      },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2897,23 +2915,20 @@
         }
       }
     },
-    "node_modules/@solana/addresses": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-5.5.1.tgz",
-      "integrity": "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==",
+    "node_modules/@solana/fixed-points": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/fixed-points/-/fixed-points-8.2.0.tgz",
+      "integrity": "sha512-w19JKErcbbENZzw4B+oBGwJXVKMIOi8TC7WxBawmpuv0XJSk6LP6surosg+XeoBHhtEsVCNHDtizi0mAS6OmMw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/assertions": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/nominal-types": "5.5.1"
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2921,19 +2936,19 @@
         }
       }
     },
-    "node_modules/@solana/assertions": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-5.5.1.tgz",
-      "integrity": "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==",
+    "node_modules/@solana/fixed-points/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.5.1"
+        "@solana/errors": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2941,23 +2956,23 @@
         }
       }
     },
-    "node_modules/@solana/codecs": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
-      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
+    "node_modules/@solana/fixed-points/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/options": "5.5.1"
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2965,19 +2980,25 @@
         }
       }
     },
-    "node_modules/@solana/codecs-core": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-5.5.1.tgz",
-      "integrity": "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==",
+    "node_modules/@solana/fixed-points/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "5.5.1"
-      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-8.2.0.tgz",
+      "integrity": "sha512-+oTPl9yRZBbppUZU8qs4eu93iWPvs4Ij+HELPHISxLFo/cuG2YZGTDcWBVEzc8XEw0DUwwBOvou/wP7v1SnH+A==",
+      "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2985,21 +3006,24 @@
         }
       }
     },
-    "node_modules/@solana/codecs-data-structures": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-5.5.1.tgz",
-      "integrity": "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==",
+    "node_modules/@solana/instruction-plans": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-8.2.0.tgz",
+      "integrity": "sha512-DDVHBAPifG3Q0s5e2hiBbfvrruLb3AhumTupDK+3f3f7MDc0Dth6rX054HtIINloqbFIw15f6/A3Z4VTh74CTg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/errors": "5.5.1"
+        "@solana/errors": "8.2.0",
+        "@solana/instructions": "8.2.0",
+        "@solana/keys": "8.2.0",
+        "@solana/promises": "8.2.0",
+        "@solana/transaction-messages": "8.2.0",
+        "@solana/transactions": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3007,20 +3031,23 @@
         }
       }
     },
-    "node_modules/@solana/codecs-numbers": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-5.5.1.tgz",
-      "integrity": "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==",
+    "node_modules/@solana/instruction-plans/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/errors": "5.5.1"
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3028,22 +3055,191 @@
         }
       }
     },
-    "node_modules/@solana/codecs-strings": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-5.5.1.tgz",
-      "integrity": "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==",
+    "node_modules/@solana/instruction-plans/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-8.2.0.tgz",
+      "integrity": "sha512-SFts84wW6hDXGSrLK5spl8nbKxKns2aR+S2ar0Zi3I0bl007heyoO7UKyxAoUvhfhObIfEIMuy2/qLoo6vDcjQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/errors": "5.5.1"
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-8.2.0.tgz",
+      "integrity": "sha512-DezFZ0/ya98nILq+eSeq9fu9onVfqQYb7mtuDctdWxY1QFJvix562zkkFuFqnjOLL7XMEpdVPMxxQOzZ33wGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0",
+        "@solana/promises": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
         "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "fastestsmallesttextencoderdecoder": {
@@ -3054,14 +3250,14 @@
         }
       }
     },
-    "node_modules/@solana/errors": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-5.5.1.tgz",
-      "integrity": "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==",
+    "node_modules/@solana/keys/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
-        "commander": "14.0.2"
+        "commander": "15.0.0"
       },
       "bin": {
         "errors": "bin/cli.mjs"
@@ -3070,7 +3266,7 @@
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3078,16 +3274,16 @@
         }
       }
     },
-    "node_modules/@solana/fast-stable-stringify": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-5.5.1.tgz",
-      "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
+    "node_modules/@solana/keys/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3095,127 +3291,54 @@
         }
       }
     },
-    "node_modules/@solana/functional": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-5.5.1.tgz",
-      "integrity": "sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==",
+    "node_modules/@solana/keys/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/instruction-plans": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
-      "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/instructions": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/promises": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/instructions": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-5.5.1.tgz",
-      "integrity": "sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/errors": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/keys": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-5.5.1.tgz",
-      "integrity": "sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/assertions": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/nominal-types": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/kit": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
-      "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-8.2.0.tgz",
+      "integrity": "sha512-1BfmnYmWe17u3RRX3HuNxjWkr2/n9Bai+yIG/XjMpgviobF3n8zsisZBJHPH2uORqvjkTFnOqGXoEQC8vUZHzw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/accounts": "5.5.1",
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/instruction-plans": "5.5.1",
-        "@solana/instructions": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/offchain-messages": "5.5.1",
-        "@solana/plugin-core": "5.5.1",
-        "@solana/programs": "5.5.1",
-        "@solana/rpc": "5.5.1",
-        "@solana/rpc-api": "5.5.1",
-        "@solana/rpc-parsed-types": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "@solana/rpc-subscriptions": "5.5.1",
-        "@solana/rpc-types": "5.5.1",
-        "@solana/signers": "5.5.1",
-        "@solana/sysvars": "5.5.1",
-        "@solana/transaction-confirmation": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/accounts": "8.2.0",
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/functional": "8.2.0",
+        "@solana/instruction-plans": "8.2.0",
+        "@solana/instructions": "8.2.0",
+        "@solana/keys": "8.2.0",
+        "@solana/offchain-messages": "8.2.0",
+        "@solana/plugin-core": "8.2.0",
+        "@solana/plugin-interfaces": "8.2.0",
+        "@solana/program-client-core": "8.2.0",
+        "@solana/programs": "8.2.0",
+        "@solana/promises": "8.2.0",
+        "@solana/rpc": "8.2.0",
+        "@solana/rpc-api": "8.2.0",
+        "@solana/rpc-parsed-types": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "@solana/rpc-subscriptions": "8.2.0",
+        "@solana/rpc-types": "8.2.0",
+        "@solana/signers": "8.2.0",
+        "@solana/subscribable": "8.2.0",
+        "@solana/sysvars": "8.2.0",
+        "@solana/transaction-confirmation": "8.2.0",
+        "@solana/transaction-introspection": "8.2.0",
+        "@solana/transaction-messages": "8.2.0",
+        "@solana/transactions": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3223,43 +3346,376 @@
         }
       }
     },
-    "node_modules/@solana/nominal-types": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-5.5.1.tgz",
-      "integrity": "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==",
+    "node_modules/@solana/kit/node_modules/@solana/accounts": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-8.2.0.tgz",
+      "integrity": "sha512-An3BICrQJQ7jR5EIgXzYnaKyCE7+ZusW9xX8m6Vj7U2cKo8t6Y3PTQ+aMjEajwzsQfxEL8QnpClFC9hdoIu7MA==",
       "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-spec": "8.2.0",
+        "@solana/rpc-types": "8.2.0"
+      },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-8.2.0.tgz",
+      "integrity": "sha512-kn2esyzFznx6Pbb+8FUe3YNKYRZUB8H81pCiXSIe1+0WJ44lRhZHMo0s4L3FQMKhWHOnlV30sWeIg8taHLVW7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-data-structures": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/options": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-data-structures": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-8.2.0.tgz",
+      "integrity": "sha512-uq59oSAXM9QR+cO7R3JmSTxBiNNJnayVWz2VHBdhhCQS8DEmd6hhqY1RVmPTpFtE0Jix5MkRV3Bu5GTmf6Y66A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/options": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-8.2.0.tgz",
+      "integrity": "sha512-b3//UzZe/uBaIpw4fT/nvCOghh5IHoNkW7FCMA/nzvQ48A16n8qpLki9/+lLHi0V0o7/Jz5Sof0UYc0aSf1Dig==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-data-structures": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-spec": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-8.2.0.tgz",
+      "integrity": "sha512-fR0hv/NP3K4WNePK9+97GYrDjzoN7kF0hlffRlSygksAC0FKvtKQ5lPBMg0ptWtswInp8Kk7Cz1zTCf6S+wLUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "@solana/subscribable": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-spec-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-8.2.0.tgz",
+      "integrity": "sha512-pKOezoP0vuVwyjUKcS4Ewl3Mm/owv/16n7RocqFC3nx94qtk5FpSOAtielUHzBQ3JUgRLJrSKonw2yWxqgtVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/sysvars": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-8.2.0.tgz",
+      "integrity": "sha512-kwhOwBfUvUGuGGGnwTGHtNVQ02O3YCfXpp4xwUhe6bjUyp9M9wEmf70up6I9x2D4uB1nHaZRfco1CXfxhcH8sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-data-structures": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/offchain-messages": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
-      "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-8.2.0.tgz",
+      "integrity": "sha512-yXfVtK1VoQ/Eyz2jH/1+avixhYcpCPkGkXuiXxA3Vf73WCvniC8mNVQ5ppsV+OqCNw62mxaFMmNiVgiAQapKuw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/nominal-types": "5.5.1"
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-data-structures": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/keys": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3267,61 +3723,784 @@
         }
       }
     },
-    "node_modules/@solana/options": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
-      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
+    "node_modules/@solana/offchain-messages/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1"
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-data-structures": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-8.2.0.tgz",
+      "integrity": "sha512-uq59oSAXM9QR+cO7R3JmSTxBiNNJnayVWz2VHBdhhCQS8DEmd6hhqY1RVmPTpFtE0Jix5MkRV3Bu5GTmf6Y66A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/plugin-core": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
-      "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-8.2.0.tgz",
+      "integrity": "sha512-V7oSIhYXbUzjd5LUY4tbSUnyBka1hmULPFKuqxNzYxeY4eLI7S8GmTOg7xg6tOC0bJ+HLPvv64asuMXAn/PklQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-8.2.0.tgz",
+      "integrity": "sha512-goOhGI493Fq+xhZ8JKl9/FDVFd0SJdkv5Lh0L2ubqekzUiGRCvHNwgXL8nVS7fso2UxIssDQmYKwXvubfhBVhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "8.2.0",
+        "@solana/addresses": "8.2.0",
+        "@solana/instruction-plans": "8.2.0",
+        "@solana/keys": "8.2.0",
+        "@solana/rpc-spec": "8.2.0",
+        "@solana/rpc-subscriptions-spec": "8.2.0",
+        "@solana/rpc-types": "8.2.0",
+        "@solana/signers": "8.2.0",
+        "@solana/transactions": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/accounts": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-8.2.0.tgz",
+      "integrity": "sha512-An3BICrQJQ7jR5EIgXzYnaKyCE7+ZusW9xX8m6Vj7U2cKo8t6Y3PTQ+aMjEajwzsQfxEL8QnpClFC9hdoIu7MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-spec": "8.2.0",
+        "@solana/rpc-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/rpc-spec": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-8.2.0.tgz",
+      "integrity": "sha512-fR0hv/NP3K4WNePK9+97GYrDjzoN7kF0hlffRlSygksAC0FKvtKQ5lPBMg0ptWtswInp8Kk7Cz1zTCf6S+wLUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "@solana/subscribable": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/rpc-spec-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-8.2.0.tgz",
+      "integrity": "sha512-pKOezoP0vuVwyjUKcS4Ewl3Mm/owv/16n7RocqFC3nx94qtk5FpSOAtielUHzBQ3JUgRLJrSKonw2yWxqgtVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@solana/program-client-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-8.2.0.tgz",
+      "integrity": "sha512-miQ7qKW0d0etaa2YAehGU3heV5Y4ip5BBCwZXb/yg8yWndTt4d4E+8z+5Q/oS5kOuFraOFYr+Uev7SQKngNXBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "8.2.0",
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/instruction-plans": "8.2.0",
+        "@solana/instructions": "8.2.0",
+        "@solana/plugin-interfaces": "8.2.0",
+        "@solana/rpc-api": "8.2.0",
+        "@solana/signers": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/accounts": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-8.2.0.tgz",
+      "integrity": "sha512-An3BICrQJQ7jR5EIgXzYnaKyCE7+ZusW9xX8m6Vj7U2cKo8t6Y3PTQ+aMjEajwzsQfxEL8QnpClFC9hdoIu7MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-spec": "8.2.0",
+        "@solana/rpc-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/rpc-spec": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-8.2.0.tgz",
+      "integrity": "sha512-fR0hv/NP3K4WNePK9+97GYrDjzoN7kF0hlffRlSygksAC0FKvtKQ5lPBMg0ptWtswInp8Kk7Cz1zTCf6S+wLUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "@solana/subscribable": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/rpc-spec-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-8.2.0.tgz",
+      "integrity": "sha512-pKOezoP0vuVwyjUKcS4Ewl3Mm/owv/16n7RocqFC3nx94qtk5FpSOAtielUHzBQ3JUgRLJrSKonw2yWxqgtVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/programs": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
-      "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-8.2.0.tgz",
+      "integrity": "sha512-yttl6ps7G9vM83pdfekyregTIqmRThFpdcrCIZ3y2qOLZ63KVxVMhNJ8kn8FrX3MyWh5rr/hTWdWKc4/U12Epg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/errors": "5.5.1"
+        "@solana/addresses": "8.2.0",
+        "@solana/errors": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3329,16 +4508,177 @@
         }
       }
     },
-    "node_modules/@solana/promises": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-5.5.1.tgz",
-      "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
+    "node_modules/@solana/programs/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-8.2.0.tgz",
+      "integrity": "sha512-i33ll+en6/Qcjw10gPeikCmU687W1pQNZPxirEuRWO/+PhE2qDQ9ZODgEakVi/1k+vSwL8sK941qfWig+3D0dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3347,26 +4687,26 @@
       }
     },
     "node_modules/@solana/rpc": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-5.5.1.tgz",
-      "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-8.2.0.tgz",
+      "integrity": "sha512-Of/2KqDf728HxKzJlwlZRvRSrgpHoDAg5+t/3RwdXWBoRQ1r3FXqwBXOrBT2g47w+fUy1iJcy5XZ7LXnXBXPIg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/fast-stable-stringify": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/rpc-api": "5.5.1",
-        "@solana/rpc-spec": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "@solana/rpc-transformers": "5.5.1",
-        "@solana/rpc-transport-http": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
+        "@solana/errors": "8.2.0",
+        "@solana/fast-stable-stringify": "8.2.0",
+        "@solana/functional": "8.2.0",
+        "@solana/rpc-api": "8.2.0",
+        "@solana/rpc-spec": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "@solana/rpc-transformers": "8.2.0",
+        "@solana/rpc-transport-http": "8.2.0",
+        "@solana/rpc-types": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3375,83 +4715,274 @@
       }
     },
     "node_modules/@solana/rpc-api": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-5.5.1.tgz",
-      "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-8.2.0.tgz",
+      "integrity": "sha512-lGvk1xeOo4cbypuD/5AAkJPHv5E3g7lqbzRIxZhsQPBkK+knVuEb7e3UncOnjuWkijZoFiB/k+Rfk83gmlhdpg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/rpc-parsed-types": "5.5.1",
-        "@solana/rpc-spec": "5.5.1",
-        "@solana/rpc-transformers": "5.5.1",
-        "@solana/rpc-types": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/keys": "8.2.0",
+        "@solana/rpc-parsed-types": "8.2.0",
+        "@solana/rpc-spec": "8.2.0",
+        "@solana/rpc-transformers": "8.2.0",
+        "@solana/rpc-types": "8.2.0",
+        "@solana/transaction-messages": "8.2.0",
+        "@solana/transactions": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/rpc-spec": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-8.2.0.tgz",
+      "integrity": "sha512-fR0hv/NP3K4WNePK9+97GYrDjzoN7kF0hlffRlSygksAC0FKvtKQ5lPBMg0ptWtswInp8Kk7Cz1zTCf6S+wLUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "@solana/subscribable": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/rpc-spec-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-8.2.0.tgz",
+      "integrity": "sha512-pKOezoP0vuVwyjUKcS4Ewl3Mm/owv/16n7RocqFC3nx94qtk5FpSOAtielUHzBQ3JUgRLJrSKonw2yWxqgtVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/rpc-parsed-types": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-5.5.1.tgz",
-      "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-8.2.0.tgz",
+      "integrity": "sha512-JJ4BfUlX8eCIUh3zm8jTkHkNLf6HyY9UjJmi4GPicFPJZ5MXSUeh42eaSxvHszXUoS7u9V30kTt1hznwfF5fqA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/rpc-spec": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.5.1.tgz",
-      "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/rpc-spec-types": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.5.1.tgz",
-      "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3460,28 +4991,28 @@
       }
     },
     "node_modules/@solana/rpc-subscriptions": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-5.5.1.tgz",
-      "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-8.2.0.tgz",
+      "integrity": "sha512-pHf/RiDqIHeGp2blseYRVjzWz4WUAY/5vkOya+BQhjx+7Odr/J19G3ZVDwExgtU95UhCDL9gVHPyAgKr0mNcUg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/fast-stable-stringify": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/promises": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "@solana/rpc-subscriptions-api": "5.5.1",
-        "@solana/rpc-subscriptions-channel-websocket": "5.5.1",
-        "@solana/rpc-subscriptions-spec": "5.5.1",
-        "@solana/rpc-transformers": "5.5.1",
-        "@solana/rpc-types": "5.5.1",
-        "@solana/subscribable": "5.5.1"
+        "@solana/errors": "8.2.0",
+        "@solana/fast-stable-stringify": "8.2.0",
+        "@solana/functional": "8.2.0",
+        "@solana/promises": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "@solana/rpc-subscriptions-api": "8.2.0",
+        "@solana/rpc-subscriptions-channel-websocket": "8.2.0",
+        "@solana/rpc-subscriptions-spec": "8.2.0",
+        "@solana/rpc-transformers": "8.2.0",
+        "@solana/rpc-types": "8.2.0",
+        "@solana/subscribable": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3490,118 +5021,805 @@
       }
     },
     "node_modules/@solana/rpc-subscriptions-api": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-5.5.1.tgz",
-      "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-8.2.0.tgz",
+      "integrity": "sha512-37UHtjFmBUagtRw9NeWViTqSJlExyuI2j88m3jJSw9c6WRw7lLzUJIRGA51ArYyhAyhtAoGjXpUZiODKSE9lEw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/rpc-subscriptions-spec": "5.5.1",
-        "@solana/rpc-transformers": "5.5.1",
-        "@solana/rpc-types": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/addresses": "8.2.0",
+        "@solana/keys": "8.2.0",
+        "@solana/rpc-subscriptions-spec": "8.2.0",
+        "@solana/rpc-transformers": "8.2.0",
+        "@solana/rpc-types": "8.2.0",
+        "@solana/transaction-messages": "8.2.0",
+        "@solana/transactions": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-5.5.1.tgz",
-      "integrity": "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-8.2.0.tgz",
+      "integrity": "sha512-R9pk8Lq030M1+bAz6e2qKv6ldGLmICFYJOaLxVifyDE4VBb1BGV3Tt1VTAaFIfHyYucmFmxGRmPFmedA3Kysqw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/rpc-subscriptions-spec": "5.5.1",
-        "@solana/subscribable": "5.5.1",
-        "ws": "^8.19.0"
+        "@solana/errors": "8.2.0",
+        "@solana/functional": "8.2.0",
+        "@solana/rpc-subscriptions-spec": "8.2.0",
+        "@solana/subscribable": "8.2.0",
+        "ws": "^8.21.3"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/rpc-subscriptions-spec": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-5.5.1.tgz",
-      "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-8.2.0.tgz",
+      "integrity": "sha512-ajcncAnQ7XzE85MZ8uajjO9E7NyLwLWFVUYG+y82vb04ZWFRN3DrMswIC4T5m14OkU3RY/Z2WGxC9nT1W4wPWw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/promises": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "@solana/subscribable": "5.5.1"
+        "@solana/errors": "8.2.0",
+        "@solana/promises": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "@solana/subscribable": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec/node_modules/@solana/rpc-spec-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-8.2.0.tgz",
+      "integrity": "sha512-pKOezoP0vuVwyjUKcS4Ewl3Mm/owv/16n7RocqFC3nx94qtk5FpSOAtielUHzBQ3JUgRLJrSKonw2yWxqgtVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/rpc-spec-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-8.2.0.tgz",
+      "integrity": "sha512-pKOezoP0vuVwyjUKcS4Ewl3Mm/owv/16n7RocqFC3nx94qtk5FpSOAtielUHzBQ3JUgRLJrSKonw2yWxqgtVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/rpc-transformers": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-5.5.1.tgz",
-      "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-8.2.0.tgz",
+      "integrity": "sha512-tiMdJ9ZRgqANBNxlXK7OSDbwixAy7K1MzowzO7vNdlJbV+0WN0Lm/X5hEhKnlU42AD+clC6t9qZjVbg7BhQrqw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/nominal-types": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
+        "@solana/errors": "8.2.0",
+        "@solana/functional": "8.2.0",
+        "@solana/nominal-types": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "@solana/rpc-types": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/rpc-spec-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-8.2.0.tgz",
+      "integrity": "sha512-pKOezoP0vuVwyjUKcS4Ewl3Mm/owv/16n7RocqFC3nx94qtk5FpSOAtielUHzBQ3JUgRLJrSKonw2yWxqgtVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/rpc-transport-http": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-5.5.1.tgz",
-      "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-8.2.0.tgz",
+      "integrity": "sha512-eOkgv52ZSMFLYNQaCsvxmPciZeXplWaPjbEcl9iZkGOAp3B2bO6KyMg8trEjaZNfcLC15+CpXMOZpMArXXSBCg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-spec": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "undici-types": "^7.19.2"
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-spec": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "undici-types": "^8.10.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3609,72 +5827,513 @@
         }
       }
     },
-    "node_modules/@solana/rpc-types": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-5.5.1.tgz",
-      "integrity": "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==",
+    "node_modules/@solana/rpc-transport-http/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/nominal-types": "5.5.1"
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/@solana/rpc-spec": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-8.2.0.tgz",
+      "integrity": "sha512-fR0hv/NP3K4WNePK9+97GYrDjzoN7kF0hlffRlSygksAC0FKvtKQ5lPBMg0ptWtswInp8Kk7Cz1zTCf6S+wLUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "@solana/subscribable": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/@solana/rpc-spec-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-8.2.0.tgz",
+      "integrity": "sha512-pKOezoP0vuVwyjUKcS4Ewl3Mm/owv/16n7RocqFC3nx94qtk5FpSOAtielUHzBQ3JUgRLJrSKonw2yWxqgtVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/rpc-spec": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-8.2.0.tgz",
+      "integrity": "sha512-fR0hv/NP3K4WNePK9+97GYrDjzoN7kF0hlffRlSygksAC0FKvtKQ5lPBMg0ptWtswInp8Kk7Cz1zTCf6S+wLUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "@solana/subscribable": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/rpc-spec-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-8.2.0.tgz",
+      "integrity": "sha512-pKOezoP0vuVwyjUKcS4Ewl3Mm/owv/16n7RocqFC3nx94qtk5FpSOAtielUHzBQ3JUgRLJrSKonw2yWxqgtVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/signers": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
-      "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-8.2.0.tgz",
+      "integrity": "sha512-wfLiDhtPMnE9Mn8IeSAJ0RMfCyHUqeNZllFLfgDY3RUsCf5s9EgMC5U+HNSvtEWJ8ABGWWR5nYyWMXTWiMeuPA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/instructions": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/nominal-types": "5.5.1",
-        "@solana/offchain-messages": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/instructions": "8.2.0",
+        "@solana/keys": "8.2.0",
+        "@solana/nominal-types": "8.2.0",
+        "@solana/offchain-messages": "8.2.0",
+        "@solana/transaction-messages": "8.2.0",
+        "@solana/transactions": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/subscribable": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.5.1.tgz",
-      "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-8.2.0.tgz",
+      "integrity": "sha512-ATJBeJkaCUIxU3JWUcgfOjnOM3nn9qDfTigEkr0Cp3xFzIHnIVwis3W4Hcc/de1z0uvOXQOIYroahDr8H+djOg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.5.1"
+        "@solana/errors": "8.2.0",
+        "@solana/promises": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3682,79 +6341,490 @@
         }
       }
     },
-    "node_modules/@solana/sysvars": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
-      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
+    "node_modules/@solana/subscribable/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/accounts": "5.5.1",
-        "@solana/codecs": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/subscribable/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/transaction-confirmation": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-5.5.1.tgz",
-      "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-8.2.0.tgz",
+      "integrity": "sha512-3L1LlMQ00l2kb3pcejvQ7vMKzyFayFhc6PqvZyh3M0/FNPfsc4z46yUf35I79SI6cuFWy2VkzA+a2ylOuCNC7w==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/promises": "5.5.1",
-        "@solana/rpc": "5.5.1",
-        "@solana/rpc-subscriptions": "5.5.1",
-        "@solana/rpc-types": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/keys": "8.2.0",
+        "@solana/promises": "8.2.0",
+        "@solana/rpc": "8.2.0",
+        "@solana/rpc-subscriptions": "8.2.0",
+        "@solana/rpc-types": "8.2.0",
+        "@solana/transaction-messages": "8.2.0",
+        "@solana/transactions": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@solana/transaction-introspection": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-introspection/-/transaction-introspection-8.2.0.tgz",
+      "integrity": "sha512-unha6ugKrZa1TcB5Slnxisa/uQC56fyYi7BDvfCVI60OLEowtOTTvmJMKe35ETMzbimjBEPE/B5EgbydOHVBnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/instructions": "8.2.0",
+        "@solana/rpc-types": "8.2.0",
+        "@solana/transaction-messages": "8.2.0",
+        "@solana/transactions": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-introspection/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-introspection/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-introspection/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-introspection/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-introspection/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-introspection/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-introspection/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-introspection/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-introspection/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@solana/transaction-messages": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-5.5.1.tgz",
-      "integrity": "sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-8.2.0.tgz",
+      "integrity": "sha512-+0U4iR/WRb8UiBXRhJJUY0+BmAOv+bQj7fifUF6o7x/IPg/K2Y4CmH4m7dOT2yhcg0KDzZPkXidXLm6saBX0Hw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/instructions": "5.5.1",
-        "@solana/nominal-types": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-data-structures": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/functional": "8.2.0",
+        "@solana/instructions": "8.2.0",
+        "@solana/nominal-types": "8.2.0",
+        "@solana/rpc-types": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3762,35 +6832,453 @@
         }
       }
     },
-    "node_modules/@solana/transactions": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-5.5.1.tgz",
-      "integrity": "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==",
+    "node_modules/@solana/transaction-messages/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/instructions": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/nominal-types": "5.5.1",
-        "@solana/rpc-types": "5.5.1",
-        "@solana/transaction-messages": "5.5.1"
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-data-structures": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-8.2.0.tgz",
+      "integrity": "sha512-uq59oSAXM9QR+cO7R3JmSTxBiNNJnayVWz2VHBdhhCQS8DEmd6hhqY1RVmPTpFtE0Jix5MkRV3Bu5GTmf6Y66A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-8.2.0.tgz",
+      "integrity": "sha512-WfbzFTf2BvpW14OIOin/9Mj29XE5GJVORAnziDK+GEiTPnruNzNkHBrd2kt/ACg12dh12kmutDj5WI3pzrN3Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-data-structures": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/functional": "8.2.0",
+        "@solana/instructions": "8.2.0",
+        "@solana/keys": "8.2.0",
+        "@solana/nominal-types": "8.2.0",
+        "@solana/rpc-types": "8.2.0",
+        "@solana/transaction-messages": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/codecs-data-structures": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-8.2.0.tgz",
+      "integrity": "sha512-uq59oSAXM9QR+cO7R3JmSTxBiNNJnayVWz2VHBdhhCQS8DEmd6hhqY1RVmPTpFtE0Jix5MkRV3Bu5GTmf6Y66A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@stablelib/base64": {
@@ -4291,6 +7779,370 @@
       },
       "peerDependencies": {
         "@solana/kit": ">=5.1.0"
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana-program/token-2022": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.16.1.tgz",
+      "integrity": "sha512-VEQHBcFFGErW+gDGQAjuLRjAbg2x7uJqoWV9EgwG82exPpqHP2VGcV0sb7DXc8uXP+IvkmZeVH81gtuKyMxpZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.7",
+        "@solana-program/record": "^0.4.0",
+        "@solana-program/system": "^0.14.0",
+        "@solana-program/zk-elgamal-proof": "^0.4.0"
+      },
+      "peerDependencies": {
+        "@solana/kit": "^8.0.0",
+        "@solana/sysvars": "^8.0.0",
+        "@solana/zk-sdk": "^0.5.1"
+      },
+      "peerDependenciesMeta": {
+        "@solana/zk-sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/accounts": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-8.2.0.tgz",
+      "integrity": "sha512-An3BICrQJQ7jR5EIgXzYnaKyCE7+ZusW9xX8m6Vj7U2cKo8t6Y3PTQ+aMjEajwzsQfxEL8QnpClFC9hdoIu7MA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-spec": "8.2.0",
+        "@solana/rpc-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/addresses": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-8.2.0.tgz",
+      "integrity": "sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/assertions": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-8.2.0.tgz",
+      "integrity": "sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/codecs-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-8.2.0.tgz",
+      "integrity": "sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/codecs-data-structures": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-8.2.0.tgz",
+      "integrity": "sha512-uq59oSAXM9QR+cO7R3JmSTxBiNNJnayVWz2VHBdhhCQS8DEmd6hhqY1RVmPTpFtE0Jix5MkRV3Bu5GTmf6Y66A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/codecs-numbers": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-8.2.0.tgz",
+      "integrity": "sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/codecs-strings": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-8.2.0.tgz",
+      "integrity": "sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/errors": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-8.2.0.tgz",
+      "integrity": "sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/nominal-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-8.2.0.tgz",
+      "integrity": "sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/rpc-spec": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-8.2.0.tgz",
+      "integrity": "sha512-fR0hv/NP3K4WNePK9+97GYrDjzoN7kF0hlffRlSygksAC0FKvtKQ5lPBMg0ptWtswInp8Kk7Cz1zTCf6S+wLUQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-spec-types": "8.2.0",
+        "@solana/subscribable": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/rpc-spec-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-8.2.0.tgz",
+      "integrity": "sha512-pKOezoP0vuVwyjUKcS4Ewl3Mm/owv/16n7RocqFC3nx94qtk5FpSOAtielUHzBQ3JUgRLJrSKonw2yWxqgtVFg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/rpc-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-8.2.0.tgz",
+      "integrity": "sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/codecs-strings": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/fixed-points": "8.2.0",
+        "@solana/nominal-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/@solana/sysvars": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-8.2.0.tgz",
+      "integrity": "sha512-kwhOwBfUvUGuGGGnwTGHtNVQ02O3YCfXpp4xwUhe6bjUyp9M9wEmf70up6I9x2D4uB1nHaZRfco1CXfxhcH8sg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "8.2.0",
+        "@solana/codecs-core": "8.2.0",
+        "@solana/codecs-data-structures": "8.2.0",
+        "@solana/codecs-numbers": "8.2.0",
+        "@solana/errors": "8.2.0",
+        "@solana/rpc-types": "8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@x402/svm/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/abitype": {
@@ -4938,15 +8790,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/confbox": {
@@ -10086,9 +13929,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.29.0.tgz",
-      "integrity": "sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.10.2.tgz",
+      "integrity": "sha512-7/+aSjzkUoLc92hV22bTW4aGanXf800zbwguhcICs0OAoCF9wDOE4wkopQ+SqfhXZm8mCK8gHpdTs7pZUWzK3w==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@polymarket/clob-client-v2": "1.0.8",
     "@scure/bip32": "^2.0.1",
     "@scure/bip39": "^1.5.0",
-    "@solana/kit": "^5.0.0",
+    "@solana/kit": "^8.0.0",
     "@x402/core": "^2.9.0",
     "@x402/evm": "^2.9.0",
     "@x402/fetch": "^2.9.0",
@@ -141,7 +141,11 @@
     "ip-address": "^10.4.0",
     "jayson": {
       "uuid": "^11.1.1"
-    }
+    },
+    "@solana/kit": "^8.0.0",
+    "@solana-program/compute-budget": "^0.18.1",
+    "@solana-program/token": "^0.16.1",
+    "@solana-program/token-2022": "^0.16.1"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
Fixes the `content-length` defect #352 targets, by taking the fix upstream already shipped instead of patching it out of the bundle.

## The defect

`@solana/rpc-transport-http@5.5.1` (`dist/index.node.mjs:73,81`):

```js
const body = toJson ? toJson(payload) : JSON.stringify(payload);
...
"content-length": body.length.toString(),
```

`body` is a string, so `.length` is UTF-16 code units, not UTF-8 bytes. Measured against a local server: a 1-emoji body is 53 units / 55 bytes, and the request fails with `Unexpected end of JSON input`, then the connection desyncs. The library's own `DISALLOWED_HEADERS` and `FORBIDDEN_HEADERS` tables (lines 8, 17) list `content-length` as a header callers must not set — it then sets it anyway.

## Why upstream, not a build-time patch

Upstream deleted the line: present in `5.5.1`, `6.3.1`, `6.5.0`, `6.7.0`; gone from `6.10.0` on. `8.2.0`'s `createHttpTransport` is byte-identical to `5.5.1`'s minus that header. undici then computes `content-length` itself, correctly and in bytes — verified on Node 22.23.2 and 24.19.0, with no fallback to `Transfer-Encoding: chunked` (some RPC providers reject chunked).

**#352's build-time strip actively blocks this upgrade.** With kit 8 installed, its esbuild plugin hard-fails the build:

```
✘ [ERROR] strip-solana-rpc-content-length matched nothing in .../index.node.mjs
  — @solana/rpc-transport-http changed shape. Update the pattern; do not ship.
```

Its fail-closed condition is "a replacement occurred", so the build breaks precisely when the dependency becomes correct.

## Why this needs `overrides`

`@x402/svm@2.25.0` (latest) still pins `@solana-program/token ^0.9.0`, `token-2022 ^0.6.1`, `compute-budget ^0.11.0` — all peering on `@solana/kit ^5.0`. Their current releases (`0.16.1`, `0.16.1`, `0.18.1`) have moved to `^8.0.0`. So the clean bump is gated on the x402 SDK, not on this repo.

The overrides are **merged into** the existing block, not replacing it — the 13 entries already there are security pins (`ws`, `tar`, `postcss`, `basic-ftp`, `ip-address`, `brace-expansion`, `jayson/uuid`, …), all still enforced.

Forcing x402's transitive deps forward is safe because `@x402/svm` uses exactly four things from them — `findAssociatedTokenPda`, `getTransferCheckedInstruction`, `getSetComputeUnitLimitInstruction`, and the two program-address constants. Driven with identical inputs on both trees, every byte matches:

| | old (token 0.9.0 / cb 0.11.0) | new (token 0.16.1 / cb 0.18.1) |
|---|---|---|
| ATA (bump) | `FGETo8T8…ra8B` (254) | identical |
| transferChecked data | `0c87d612000000000006` | identical |
| transferChecked accounts | 4 accounts, roles `1,0,1,0` | identical |
| computeBudget data | `02400d0300` | identical |
| TOKEN / TOKEN_2022 program | unchanged | unchanged |

npm resolves **one deduped `@solana/kit@8.2.0`** — no second copy, which matters because `noExternal: [/.*/]` would bundle both.

## Verified

- `tsc --noEmit` clean
- 1088 passed / 1 skipped
- `npm run build` + dist smoke green
- built bundles carry **zero** manual `content-length` lines, with no patching of any kind

## NOT verified — needs a human before this ships

**A live Solana payment.** The only tests touching the signing path mock `@x402/svm` wholesale (`src/proxy.solana-rpc-override.test.ts:22,32`), and nothing in `src/` calls the token builders directly — they live inside x402's compiled code. Green tests say nothing about the real money path. One real Solana-rail paid request should gate the merge.

`dist/` is deliberately not regenerated here to keep the diff reviewable; `publish.yml` rebuilds from source anyway (`npm ci` → build → publish). Note main's committed `dist/` is separately stale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated underlying Solana components to newer compatible versions.
  - No direct user-facing feature or behavior changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->