### PR TITLE
fix(desktop): the staged runtime was still shipping axios 0.27.2

### DIFF
--- a/apps/desktop/runtime/pnpm-lock.yaml
+++ b/apps/desktop/runtime/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@blockrun/clawrouter': 0.12.267
+  axios: ^1.19.0
 
 importers:
 
@@ -2955,6 +2956,7 @@ packages:
   '@smithy/node-http-handler@4.12.0':
     resolution: {integrity: sha512-0mq1pHadfyXCYCqm2cNpbjNIT+fbaUpNxewZb/YNr2L0IrEVMOb8gM/Fl4K6XvHCW3uSNDFwPl/+iKm0bx9jYg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Depreacted due to a memory leak issue https://github.com/smithy-lang/smithy-typescript/issues/2258
 
   '@smithy/node-http-handler@4.7.3':
     resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
@@ -3505,9 +3507,6 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  axios@0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
 
   axios@1.20.0:
     resolution: {integrity: sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==}
@@ -8030,7 +8029,7 @@ snapshots:
       '@ethersproject/wallet': 5.8.0
       '@polymarket/builder-abstract-signer': 0.0.1(zod@4.5.4)
       '@polymarket/builder-signing-sdk': 0.0.8
-      axios: 0.27.2
+      axios: 1.20.0
       browser-or-node: 3.0.0
       ethers: 5.8.0
       tsx: 4.23.13
@@ -8759,13 +8758,6 @@ snapshots:
   argparse@2.0.1: {}
 
   asynckit@0.4.0: {}
-
-  axios@0.27.2:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.6
-    transitivePeerDependencies:
-      - debug
 
   axios@1.20.0:
     dependencies:

--- a/apps/desktop/runtime/pnpm-workspace.yaml
+++ b/apps/desktop/runtime/pnpm-workspace.yaml
@@ -9,5 +9,10 @@ packages:
   - "."
 overrides:
   "@blockrun/clawrouter": 0.12.267
+  # Mirrors the root package.json security pins. This runtime is a SEPARATE pnpm
+  # install that electron-builder packages into the app, so the root `overrides`
+  # never reach it — @polymarket/builder-relayer-client was still dragging
+  # axios 0.27.2 in here long after v0.12.238 fixed it at the root.
+  axios: ^1.19.0
 minimumReleaseAgeExclude:
   - "@blockrun/clawrouter@0.12.267"


### PR DESCRIPTION
## Summary

The repo's 35 open Dependabot alerts aren't where anyone has been looking. **26 of them are against `apps/desktop/runtime/pnpm-lock.yaml`, not the root lockfile** — which is why root-side override work never moved the number.

`v0.12.238` pinned axios forward at the root (`"axios": "$axios"`), and that worked: the root tree carries exactly one copy, at 1.19.0. But the Desktop staged runtime is a **separate pnpm install with its own `overrides` block**, so no root pin reaches it. `@polymarket/builder-relayer-client@0.0.10` has been pulling `axios: 0.27.2` into it ever since — into the tree `electron-builder` packages and ships as the app.

Same dependency, same fix, second install nobody applied it to.

## The change

Mirror the pin into `runtime/pnpm-workspace.yaml` and relock. The relock is surgical — 14 lines:

- `axios@0.27.2` gone, along with its `follow-redirects` / `form-data` transitives
- everything resolves onto `axios@1.20.0`, which the tree already carried
- the single `@blockrun/clawrouter` pin is untouched, so `runtime-version.test.ts` still passes (2/2)

```
$ grep -oE "axios@[0-9][^:( ]*" apps/desktop/runtime/pnpm-lock.yaml | sort -u
axios@1.20.0        # (the other match is gaxios@7.3.1)
```

## What this does not cover

The remaining 9 root alerts are 8 `development`-scope (fast-uri, vitest, hono — openclaw and test transitives) plus `elliptic <= 6.6.1`, which resolves to 6.6.1 with no patched version published. Nothing actionable there.

Worth deciding separately whether the runtime workspace should carry the rest of the root security pins as a matter of policy, rather than one dependency at a time — the structural problem is that two lockfiles ship and only one has ever been hardened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mUab3xrLHNpYqVHJLgJHL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added a security pin for Axios in the desktop runtime environment to help ensure a consistent protected dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->