### PR TITLE
chore(deps): patch hono, and drop two overrides that pinned nothing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6562,9 +6562,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
-      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -129,19 +129,15 @@
   "overrides": {
     "axios": "$axios",
     "undici": "$undici",
-    "basic-ftp": "^5.3.1",
     "ws": "^8.21.2",
     "postcss": "^8.5.25",
     "esbuild": "^0.28.1",
     "brace-expansion": "^5.0.9",
     "fast-uri": "^3.1.5",
     "tar": "^7.5.22",
-    "hono": "^4.13.0",
+    "hono": "^4.13.5",
     "@hono/node-server": "^2.1.0",
-    "ip-address": "^10.4.0",
-    "jayson": {
-      "uuid": "^11.1.1"
-    }
+    "ip-address": "^10.4.0"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
Follow-on from #376. Having found that the Desktop runtime had never had *any* of the root security pins, the obvious next question was whether the root ones are doing what they claim. Audited all 13 against what the lockfile actually resolves.

## hono was inside the advisory range

Pinned `^4.13.0`, resolving to **4.13.1**. Both open hono advisories (the `toSSG()` write and the query parser reading past the URL fragment) are fixed in **4.13.5**. Pinned `^4.13.5`; resolves to 4.13.7. Three lines of lockfile.

## Two overrides pin nothing

`basic-ftp` and `jayson > uuid` match no package in the tree — none of `basic-ftp`, `jayson` or `uuid` is installed at all. Leftovers from dependencies that have since gone. An override matching nothing is worse than no override, because it reads as protection: #358's body cites "the 13 entries already there are security pins … all still enforced", and two of them enforce nothing. Removed; no resolution changes.

## The other nine are fine

One copy each, all above their advisories: `axios` 1.19.0, `undici` 8.10.0, `ws` 8.21.3, `postcss` 8.5.26, `esbuild` 0.28.1, `brace-expansion` 5.0.9, `fast-uri` 3.1.5, `tar` 7.5.22, `ip-address` 10.4.0.

Worth knowing while reading the security tab: **the four `fast-uri` "high" alerts are phantom.** They cite ranges `>= 2.3.1, < 2.4.5`, and the tree contains exactly one `fast-uri`, at 3.1.5 (`fast-uri/-/fast-uri-3.1.5.tgz`, the only tarball in the lockfile). They should clear on the next dependency-graph pass.

## What is deliberately not fixed

`vitest` `^4.1.3` resolves to 4.1.10, and the `@vitest/mocker` path-traversal advisory is fixed in 4.1.11. Every route to it — `vitest@^4.1.11`, exact `vitest@4.1.11` — crashes Arborist:

```
npm error Cannot read properties of null (reading 'edgesOut')
  at #loadPeerSet (build-ideal-tree.js:1289)
  ... silly unfinished npm timer idealTree:node_modules/vitest
```

Same failure as #373, and retrying does not clear it; unmodified `main` resolves fine, so the bump is the trigger. vitest declares exact-version peers on a dozen optional `@vitest/*` packages, which is the likely cause. It is development scope and not shipped, and hand-editing a lockfile on a package that publishes real-money code to chase a test-runner advisory is a bad trade. Left for when npm or vitest moves.

## Verification

Clean `npm ci` from this lockfile into a scratch tree: `hono` 4.13.7, `tsc --noEmit` clean, **1088 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mUab3xrLHNpYqVHJLgJHL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Hono package override to version 4.13.5.
  - Removed package-specific overrides for basic-ftp and jayson, including its uuid override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->